### PR TITLE
Phase 2A: Add reported citation extraction and jade.io URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,16 @@ Model Context Protocol (MCP) server for Australian legal research. Searches Aust
   - Manual override available via `sortBy` parameter
 - ✅ **Legislation search**: Find Australian Commonwealth and State legislation
 - ✅ **Primary sources only**: Filters out journal articles and commentary
-- ✅ **Citation extraction**: Extracts neutral citations like `[2025] HCA 26`
+- ✅ **Citation extraction**: Extracts both neutral citations `[2025] HCA 26` and reported citations `(2024) 350 ALR 123`
+- ✅ **jade.io URL support**: Fetch document text from jade.io URLs (requires user access)
 - ✅ **Paragraph preservation**: Keeps `[N]` paragraph numbers for pinpoint citations
 - ✅ **Multiple formats**: JSON, text, markdown, or HTML output
-- ✅ **Document retrieval**: Full text from HTML and PDF sources
+- ✅ **Document retrieval**: Full text from HTML and PDF sources (AustLII, jade.io)
 - ✅ **OCR support**: Tesseract OCR fallback for scanned PDFs
 
 ### Roadmap
-- 🔜 **Multi-source**: Will add jade.io for reported judgements
+- 🔶 **jade.io integration**: Partial support - users can provide jade.io URLs for document fetching
+- 🔜 **jade.io search**: Pending API access from jade.io for search integration
 - 🔜 **Page numbers**: Will extract page numbers from reported versions
 - 🔜 **Authority ranking**: Will prioritise reported over unreported judgements
 
@@ -183,11 +185,15 @@ src/
 
 See [docs/ROADMAP.md](docs/ROADMAP.md) and [Issue #2](https://github.com/russellbrenner/auslaw-mcp/issues/2) for detailed development plans.
 
+**Completed**:
+1. ✅ Search relevance with intelligent sorting (Phase 1)
+2. ✅ Reported citation extraction (Phase 2A)
+3. ✅ jade.io URL support for document fetching (Phase 2A)
+
 **Next priorities**:
-1. ✅ ~~Fix search relevance for case name queries~~ (Completed)
-2. Add jade.io integration for reported judgements
-3. Extract page numbers for pinpoint citations
-4. Implement authority-based result ranking
+1. Contact jade.io for API access (Phase 2B)
+2. Extract page numbers for pinpoint citations (Phase 3)
+3. Implement authority-based result ranking (Phase 4)
 
 ## License
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -183,10 +183,37 @@ function calculateAuthorityScore(result: SearchResult): number {
 2. ✅ ~~Preserve paragraph numbers properly~~ (already working)
 3. ✅ ~~Add search mode parameter (relevance/date/auto)~~ (COMPLETED)
 
+### ✅ Phase 2A: Reported Citations & jade.io Support (COMPLETED)
+
+**Implemented features:**
+1. ✅ Reported citation extraction from AustLII results
+   - Extracts citations like `(2024) 350 ALR 123`, `(1992) 175 CLR 1`
+   - Supports common law report patterns (CLR, ALR, ALJR, etc.)
+   - Automatically extracted from titles and summaries
+2. ✅ jade.io URL support in document fetcher
+   - Users can paste jade.io URLs they have access to
+   - Special HTML parsing for jade.io document structure
+   - Falls back to generic extraction when needed
+3. ✅ Enhanced SearchResult interface
+   - Added `reportedCitation` field
+   - Updated `source` to support both "austlii" and "jade"
+4. ✅ New test coverage (4 additional tests)
+
+**What this enables:**
+- Users can now see both neutral and reported citations
+- More complete citation information for legal research
+- jade.io integration without needing API access
+- Users leverage their own jade.io subscriptions
+
+**Technical implementation:**
+- `extractReportedCitation()` function with regex patterns
+- `extractTextFromJadeHtml()` for jade.io-specific parsing
+- Updated test suite with 18 total scenarios
+
 ### Should Have (Following Sprint)
-1. 🔶 Add jade.io integration for reported judgments
-2. 🔶 Implement page number extraction
-3. 🔶 Add authority-based ranking
+1. 🔶 Contact jade.io for search API access (Phase 2B)
+2. 🔶 Implement page number extraction (Phase 3)
+3. 🔶 Add authority-based ranking (Phase 4)
 
 ### Nice to Have (Future)
 1. 📋 BarNet Jade integration


### PR DESCRIPTION
## Overview

This PR implements **Phase 2A** enhancements: reported citation extraction and jade.io URL support. This provides more complete citation information and enables users to leverage their jade.io subscriptions.

## What's New

### 1. Reported Citation Extraction 📚
Automatically extracts reported citations from AustLII search results:
- **Examples**: `(2024) 350 ALR 123`, `(1992) 175 CLR 1`, `(2024) 98 ALJR 456`
- **Common reporters**: CLR, ALR, ALJR, HCA, and more
- **Extracted from**: Titles and summaries
- **Format**: Supports both `(YYYY)` and `[YYYY]` styles

### 2. jade.io URL Support 🔗
Users can now provide jade.io URLs for document fetching:
- Paste any jade.io URL they have access to
- Special HTML parsing for jade.io structure
- Leverages users' own subscriptions
- No API key required

### 3. Enhanced Data Model
- Added `reportedCitation` field to `SearchResult`
- Updated `source` type to support `"austlii" | "jade"`
- More complete citation information

## Use Cases

### Before:
```json
{
  "title": "Mabo v Queensland (No 2)",
  "neutralCitation": "[1992] HCA 23",
  "reportedCitation": null  // ❌ Missing
}
```

### After:
```json
{
  "title": "Mabo v Queensland (No 2)",
  "neutralCitation": "[1992] HCA 23",
  "reportedCitation": "(1992) 175 CLR 1"  // ✅ Extracted!
}
```

### jade.io Integration:
```json
// Users can now fetch from jade.io URLs
{
  "tool": "fetch_document_text",
  "url": "https://jade.io/article/12345"  // Works if user has access
}
```

## Technical Implementation

### Code Changes

#### `src/services/austlii.ts`
- Added `extractReportedCitation()` function
  - Regex patterns for common law reports
  - Handles multiple citation formats
- Updated result parsing to extract reported citations
- Enhanced `SearchResult` interface

#### `src/services/fetcher.ts`
- Added `extractTextFromJadeHtml()` for jade.io-specific parsing
- Updated `extractTextFromHtml()` with URL detection
- Special selectors for jade.io document structure

#### `src/test/scenarios.test.ts`
- New test suite: "Reported citations and jade.io support"
- 4 new test scenarios (18 total):
  1. Reported citation extraction validation
  2. High Court case citation formats
  3. jade.io URL handling
  4. Source field validation

### Files Changed
- **5 files**: 207 insertions, 13 deletions
- Source code: 3 files
- Documentation: 2 files
- Tests: 4 new scenarios

## Test Results

All **18 test scenarios** pass ✅

New tests cover:
- Reported citation format validation
- Common reporter abbreviations (CLR, ALR, ALJR)
- jade.io URL pattern recognition
- Source field type safety

## Benefits

### For Users:
- **More complete citations**: Both neutral and reported citations
- **Better research**: Find cases in law reports
- **jade.io access**: Use their existing subscriptions
- **No extra cost**: No API fees or new subscriptions needed

### For Developers:
- **Backward compatible**: All existing code works unchanged
- **Optional fields**: `reportedCitation` is optional
- **Type safe**: Enhanced TypeScript interfaces
- **Well tested**: 18 scenarios covering all features

## Approach: Why This Design?

### Reported Citations
Since jade.io doesn't have a public API, we extract reported citations from AustLII's HTML. This gives users citation information without requiring jade.io access.

### jade.io URL Support
Rather than scraping jade.io (which would violate ToS), we allow users to provide URLs they can already access. This:
- ✅ Respects jade.io's terms of service
- ✅ Leverages users' existing subscriptions
- ✅ Provides value without API access
- ✅ Opens door for future API partnership

## Next Steps

### Phase 2B (Future):
1. Contact jade.io about API partnership
2. If granted: Implement search integration
3. If not: This approach already provides value

### Phase 3 (Following):
1. Extract page numbers from reported versions
2. Paragraph-to-page mapping
3. Enhanced pinpoint citations

## Breaking Changes

**None.** This is fully backward compatible:
- New fields are optional
- Existing queries work unchanged
- No API changes

## Checklist

- ✅ Code compiles without errors
- ✅ All tests pass (18/18)
- ✅ Documentation updated
- ✅ Backward compatible
- ✅ No breaking changes
- ✅ TypeScript strict mode passes
- ✅ Related to Issue #2

---

## For Reviewers

### Key files to review:
1. `src/services/austlii.ts` - Citation extraction logic
2. `src/services/fetcher.ts` - jade.io URL handling  
3. `src/test/scenarios.test.ts` - New test coverage

### Testing:
```bash
git checkout phase-2a-reported-citations
npm install
npm run build
npm test
```

### Try it:
Search for "Mabo" and check if `reportedCitation` field appears in results with CLR citation.