### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Model Context Protocol (MCP) server for Australian legal research. Searches AustLII for case law and legislation, retrieves full-text judgements with paragraph numbers preserved, and supports OCR for scanned PDFs.
 
+<a href="https://glama.ai/mcp/servers/@russellbrenner/auslaw-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@russellbrenner/auslaw-mcp/badge" alt="AusLaw MCP server" />
+</a>
+
 **Status**: ✅ Working MVP with intelligent search relevance
 
 ## Features


### PR DESCRIPTION
This PR adds a badge for the [AusLaw MCP](https://glama.ai/mcp/servers/@russellbrenner/auslaw-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@russellbrenner/auslaw-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@russellbrenner/auslaw-mcp/badge" alt="AusLaw MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.