### PR TITLE
Add Warp/Oz project rules for side-by-side agent setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ coverage
 *.swo
 *~
 
+# Warp
+.warp/
+
 # Generated docs
 docs/api
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AI Agent Instructions for AusLaw MCP
 
-This document provides guidance for AI agents (Claude Code, Cursor, etc.) working on this project.
+This document provides guidance for AI agents (Claude Code, Warp/Oz, Cursor, etc.) working on this project.
 
 ## Project Overview
 
@@ -52,16 +52,19 @@ src/
 ## Core Principles
 
 ### 1. Primary Sources Only
+
 - **NEVER** return journal articles, commentary, or secondary sources
 - **ALWAYS** filter URLs containing `/journals/`
 - Focus: Cases from `/cases/` and legislation from `/legis/`
 
 ### 2. Citation Accuracy
+
 - Extract and preserve neutral citations: `[2025] HCA 26`
 - Preserve paragraph numbers in `[N]` format
 - Future: Extract page numbers for reported citations
 
 ### 3. Search Quality
+
 - ✅ **FIXED**: Intelligent sorting now returns the actual case being searched for
 - **Implementation**: Auto-detects case name queries vs topic searches
   - Case names ("X v Y", "Re X", citations) → relevance sorting
@@ -69,6 +72,7 @@ src/
 - **Configuration**: `sortBy` parameter supports "auto" (default), "relevance", "date"
 
 ### 4. Real-World Testing
+
 - Tests hit live AustLII API (non-deterministic)
 - Validate with actual legal queries (e.g., "negligence duty of care")
 - Live tests in `src/test/scenarios.test.ts` are skipped in CI (`process.env.CI`) to avoid flaky failures
@@ -94,27 +98,28 @@ src/
 
 ### Environment Variables
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `JADE_SESSION_COOKIE` | For jade.io fetch | Full cookie header from an authenticated jade.io browser session (`IID=...; alcsessionid=...; cf_clearance=...`). Without this, `fetch_document_text` for jade.io URLs throws an actionable error. |
-| `AUSTLII_SEARCH_BASE` | No | Override AustLII search endpoint (default: `https://www.austlii.edu.au/cgi-bin/sinosrch.cgi`) |
-| `AUSTLII_REFERER` | No | Referer header for AustLII requests |
-| `AUSTLII_USER_AGENT` | No | User-Agent string for AustLII requests |
-| `AUSTLII_TIMEOUT` | No | AustLII request timeout in ms |
-| `OCR_LANGUAGE` | No | Tesseract OCR language (default: `eng`) |
-| `OCR_OEM` | No | Tesseract OCR engine mode |
-| `OCR_PSM` | No | Tesseract page segmentation mode |
-| `DEFAULT_SEARCH_LIMIT` | No | Default number of search results (default: 10) |
-| `MAX_SEARCH_LIMIT` | No | Maximum allowed search results (default: 50) |
-| `DEFAULT_OUTPUT_FORMAT` | No | Default format: `json`, `text`, `markdown`, `html` |
-| `DEFAULT_SORT_BY` | No | Default sort: `auto`, `relevance`, `date` |
-| `LOG_LEVEL` | No | Logging verbosity: `error`, `warn`, `info`, `debug` |
+| Variable                | Required          | Description                                                                                                                                                                                        |
+| ----------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `JADE_SESSION_COOKIE`   | For jade.io fetch | Full cookie header from an authenticated jade.io browser session (`IID=...; alcsessionid=...; cf_clearance=...`). Without this, `fetch_document_text` for jade.io URLs throws an actionable error. |
+| `AUSTLII_SEARCH_BASE`   | No                | Override AustLII search endpoint (default: `https://www.austlii.edu.au/cgi-bin/sinosrch.cgi`)                                                                                                      |
+| `AUSTLII_REFERER`       | No                | Referer header for AustLII requests                                                                                                                                                                |
+| `AUSTLII_USER_AGENT`    | No                | User-Agent string for AustLII requests                                                                                                                                                             |
+| `AUSTLII_TIMEOUT`       | No                | AustLII request timeout in ms                                                                                                                                                                      |
+| `OCR_LANGUAGE`          | No                | Tesseract OCR language (default: `eng`)                                                                                                                                                            |
+| `OCR_OEM`               | No                | Tesseract OCR engine mode                                                                                                                                                                          |
+| `OCR_PSM`               | No                | Tesseract page segmentation mode                                                                                                                                                                   |
+| `DEFAULT_SEARCH_LIMIT`  | No                | Default number of search results (default: 10)                                                                                                                                                     |
+| `MAX_SEARCH_LIMIT`      | No                | Maximum allowed search results (default: 50)                                                                                                                                                       |
+| `DEFAULT_OUTPUT_FORMAT` | No                | Default format: `json`, `text`, `markdown`, `html`                                                                                                                                                 |
+| `DEFAULT_SORT_BY`       | No                | Default sort: `auto`, `relevance`, `date`                                                                                                                                                          |
+| `LOG_LEVEL`             | No                | Logging verbosity: `error`, `warn`, `info`, `debug`                                                                                                                                                |
 
 See README.md "jade.io Authenticated Access" for cookie extraction instructions. See `src/config.ts` for all defaults.
 
 ### Testing Requirements
 
 Every PR must include:
+
 - ✅ TypeScript compilation passes (`npm run build`)
 - ✅ All tests pass (`npm test`)
 - ✅ New tests for new features
@@ -123,6 +128,7 @@ Every PR must include:
 ### Search Implementation Notes
 
 **Current AustLII search** (`src/services/austlii.ts`):
+
 - Uses `https://www.austlii.edu.au/cgi-bin/sinosrch.cgi` (configurable via `AUSTLII_SEARCH_BASE`)
 - Parameters: `method=boolean`, `query=...`, `meta=/austlii`, `view=date|relevance`
 - Parses `<ol><li>` result structure with Cheerio
@@ -134,12 +140,14 @@ Every PR must include:
 - **Configurable sorting**: Explicit control via `sortBy` parameter when needed
 
 **Citation service** (`src/services/citation.ts`):
+
 - `parseCitation()`: Extracts neutral and reported citations from free text
 - `formatAGLC4()`: Formats citations per AGLC4 rules (title, neutral, reported, pinpoint)
 - `validateCitation()`: HEAD-checks a neutral citation against AustLII, returns canonical URL
 - `generatePinpoint()`: Finds a paragraph by number or phrase in a `ParagraphBlock[]` array
 
 **jade.io service** (`src/services/jade.ts`):
+
 - `searchJade(query, options)` calls the `proposeCitables` GWT-RPC method (reverse-engineered via HAR analysis). Returns `[]` gracefully when `JADE_SESSION_COOKIE` is unset.
 - `search_cases` runs AustLII and jade.io in parallel, deduplicating results by neutral citation (jade results preferred as they have richer citation data).
 - Article metadata resolution: `resolveArticle(articleId)` fetches the page `<title>` tag to extract case name and neutral citation without needing JavaScript execution
@@ -149,14 +157,16 @@ Every PR must include:
 - Key exports: `searchJade`, `resolveArticle`, `resolveArticleFromUrl`, `articleToSearchResult`, `enrichWithJadeLinks`, `buildCitationLookupUrl`, `isJadeUrl`, `extractArticleId`
 
 **GWT-RPC utilities** (`src/services/jade-gwt.ts`):
+
 - Low-level implementation of jade.io's GWT-RPC wire protocol (reverse-engineered, 2026-03-02)
-- `encodeGwtInt(n)`: Encodes integers using GWT's custom base-64 charset (A-Z, a-z, 0-9, $, _)
+- `encodeGwtInt(n)`: Encodes integers using GWT's custom base-64 charset (A-Z, a-z, 0-9, $, \_)
 - `buildAvd2Request(articleId)`: Builds the POST body for `ArticleViewRemoteService.avd2Request` — the primary method jade.io's GWT app uses to load article content
 - `parseAvd2Response(text)`: Strips `//OK` prefix, joins GWT `"+"` string concatenation, JSON-parses, and extracts the longest HTML string from the nested string table
 - `buildGetMetadataRequest(articleId)`: Lighter-weight call that returns schema.org JSON with case name and neutral citation
 - Strong names and the permutation hash may need refreshing if jade.io redeploys its GWT app (inspect `X-GWT-Permutation` from a live browser session)
 
 **Document fetching** (`src/services/fetcher.ts`):
+
 - Handles HTML, PDF, and OCR fallback (Tesseract)
 - Extracts text while preserving `[N]` paragraph markers as `ParagraphBlock[]`
 - For jade.io URLs: routes to `fetchJadeArticleContent()` via `JADE_SESSION_COOKIE`; calls `avd2Request` GWT-RPC to bypass the JavaScript SPA and retrieve full HTML directly
@@ -171,7 +181,7 @@ Every PR must include:
 // src/services/newsource.ts
 export async function searchNewSource(
   query: string,
-  options: SearchOptions
+  options: SearchOptions,
 ): Promise<SearchResult[]> {
   // Implementation
 }
@@ -205,14 +215,14 @@ function extractTextFromHtml(html: string): string {
 
   // Preserve paragraph numbers
   $('[class*="para"]').each((_, el) => {
-    const paraNum = $(el).attr('data-para-num');
+    const paraNum = $(el).attr("data-para-num");
     if (paraNum) {
       $(el).prepend(`[${paraNum}] `);
     }
   });
 
   // Extract preserving structure
-  return $('body').text();
+  return $("body").text();
 }
 ```
 
@@ -223,7 +233,19 @@ function extractTextFromHtml(html: string): string {
 ```typescript
 // 1. Update SearchOptions interface in src/services/austlii.ts
 export interface SearchOptions {
-  jurisdiction?: "cth" | "vic" | "nsw" | "qld" | "sa" | "wa" | "tas" | "nt" | "act" | "federal" | "nz" | "other";
+  jurisdiction?:
+    | "cth"
+    | "vic"
+    | "nsw"
+    | "qld"
+    | "sa"
+    | "wa"
+    | "tas"
+    | "nt"
+    | "act"
+    | "federal"
+    | "nz"
+    | "other";
   limit?: number;
   type: "case" | "legislation";
   sortBy?: "relevance" | "date" | "auto"; // ✅ IMPLEMENTED
@@ -257,13 +279,16 @@ if (sortMode === "relevance" && isCaseNameQuery(query)) {
 ## Known Issues & Workarounds
 
 ### ~~Issue: Search returns citing cases, not target case~~ ✅ FIXED
+
 **Solution**: Implemented intelligent sorting with auto-detection and title matching
 
 ### Issue: Page numbers lost in extraction
+
 **Workaround**: Use paragraph numbers for pinpoints
 **Fix planned**: Parse page markers from reported judgement HTML
 
 ### ~~Issue: No deduplication across sources~~ ✅ FIXED
+
 **Solution**: `enrichWithJadeLinks()` adds jade.io lookup URLs to AustLII results; jade.io search is a placeholder pending API access
 
 ## Resources

--- a/WARP.md
+++ b/WARP.md
@@ -1,0 +1,90 @@
+# auslaw-mcp — Warp/Oz Project Rules
+
+## Project Overview
+
+MCP server for Australian/NZ legal research. Searches AustLII and jade.io, retrieves full-text judgments, formats AGLC4 citations. See `AGENTS.md` for full architecture and domain context.
+
+## Build & Test
+
+```bash
+npm run build          # TypeScript compile (MUST pass before committing)
+npm test               # All tests (unit + integration + perf; integration hits live services)
+npx vitest run src/test/unit/  # Unit tests only (fast, no network)
+npm run lint           # ESLint (flat config via eslint.config.mjs)
+npm run lint:fix       # Auto-fix lint issues
+npm run format:check   # Prettier check
+```
+
+- Always run `npm run build` before pushing
+- Unit tests must all pass; integration/perf test failures from network timeouts are acceptable
+- ESLint uses flat config (`eslint.config.mjs`), NOT legacy `.eslintrc`
+- Pre-commit hook runs `lint-staged` (eslint --fix + prettier --write on staged .ts files)
+
+## Key Architecture
+
+- `src/index.ts` — MCP server, 10 tool registrations
+- `src/services/jade-gwt.ts` — GWT-RPC protocol: `proposeCitables` (search), `avd2Request` (fetch), citator, strong names
+- `src/services/jade.ts` — jade.io integration: `searchJade`, `resolveArticle`, `searchCitingCases`
+- `src/services/austlii.ts` — AustLII search with authority-based ranking
+- `src/services/citation.ts` — AGLC4 formatting, validation, pinpoints
+- `src/services/fetcher.ts` — Document retrieval (HTML, PDF, OCR, jade.io GWT-RPC)
+- `src/utils/` — formatter, logger, rate-limiter, url-guard
+
+## Code Style
+
+- TypeScript strict mode; all code must type-check with `npm run build`
+- Prettier: 2-space indent, double quotes, trailing commas, 100 char width (see `.prettierrc.json`)
+- ESLint: no console (except warn/error), no unused vars (prefix unused args with `_`), no explicit any (warn)
+- Wrap network calls in try/catch with descriptive errors
+- Define TypeScript interfaces before implementation
+- Use enums/constants for repeated values (no magic strings)
+- ESM modules (`"type": "module"` in package.json, `NodeNext` module resolution)
+
+## Testing
+
+- Vitest as test runner (`vitest.config.ts`)
+- Unit tests in `src/test/unit/` — deterministic, use HTML fixtures from `src/test/fixtures/`
+- Integration tests in `src/test/scenarios.test.ts` — hit live AustLII/jade.io, skipped when `CI=true`
+- Performance tests in `src/test/performance/`
+- Test timeout: 60s (both test and hook)
+- Coverage thresholds: 70% lines/functions/branches/statements
+
+## Domain Rules
+
+- **Primary sources only**: NEVER return journal articles, commentary, or secondary sources
+- **Always filter** URLs containing `/journals/`
+- **Preserve paragraph numbers** in `[N]` format — critical for legal citations
+- **Citation accuracy**: extract and preserve neutral citations like `[2025] HCA 26`
+
+## jade.io GWT-RPC
+
+Reverse-engineered GWT-RPC protocol. Key points:
+
+- Strong names change on jade.io redeployment; update from HAR captures
+- `proposeCitables` = search endpoint; `avd2Request` = fetch judgment content
+- `LeftoverRemoteService` = citation search ("who cites this article")
+- Article IDs resolved via public GET to `jade.io/article/{id}` (no auth needed)
+- See `docs/jade-gwt-protocol.md` for full protocol documentation
+
+## Environment Variables
+
+See `.env.example` for all variables with defaults. Key ones:
+
+- `JADE_SESSION_COOKIE` — Required for jade.io fetch (contains `IID`, `alcsessionid`, `cf_clearance`)
+- `LOG_LEVEL` — Logging verbosity (0=DEBUG, 1=INFO, 2=WARN, 3=ERROR)
+- `DEFAULT_SORT_BY` — Search sort order: `auto` (default), `relevance`, `date`
+
+## CI
+
+GitHub Actions workflow (`.github/workflows/main.yml`):
+
+- Lint + format check + type check
+- Test on Node 20.x and 22.x with `CI=true`
+- Security audit (npm audit)
+
+## Related Agent Files
+
+- `AGENTS.md` — Shared agent instructions (architecture, domain, common tasks)
+- `CLAUDE.md` — Claude Code-specific instructions
+- `docs/ROADMAP.md` — Planned features
+- `docs/architecture.md` — Architecture overview


### PR DESCRIPTION
## Summary

Add Warp/Oz project rules so Oz agents can work on this repo side-by-side with Claude Code and other coding agents.

## Changes

- **`WARP.md`** — New project rules file for Warp/Oz, covering build/test commands, architecture overview, code style, testing conventions, domain rules, and cross-references to shared docs (`AGENTS.md`, `CLAUDE.md`).
- **`AGENTS.md`** — Updated agent list to include Warp/Oz alongside Claude Code and Cursor.
- **`.gitignore`** — Added `.warp/` directory exclusion.

## Agent setup overview

Each agent tool reads its own rules file:

| Agent | Rules file |
|-------|-----------|
| Claude Code | `CLAUDE.md` |
| Warp/Oz | `WARP.md` |
| All agents | `AGENTS.md` (shared architecture & domain context) |

_This PR was generated with [Oz](https://www.warp.dev/oz)._
