### PR TITLE
feat: AGLC4 validation improvements, local citation cache, and source store

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,8 @@
  * Loads configuration from environment variables with defaults
  */
 
+import path from "node:path";
+
 export interface Config {
   austlii: {
     searchBase: string;
@@ -27,6 +29,18 @@ export interface Config {
     outputFormat: string;
     sortBy: string;
   };
+  cache: {
+    /** Base directory for the .auslaw/ cache folder. Defaults to cwd. */
+    dir: string;
+    /** Project name used in bib exports and multi-doc tracking. Defaults to basename of dir. */
+    projectName: string;
+  };
+  sources: {
+    /** Directory where source markdown files are saved. */
+    dir: string;
+    /** When true, fetch_document_text automatically saves a local source copy. */
+    fetchByDefault: boolean;
+  };
 }
 
 /**
@@ -35,6 +49,10 @@ export interface Config {
  * @returns A fully-populated {@link Config} object
  */
 export function loadConfig(): Config {
+  const cacheDir = process.env.AUSLAW_CACHE_DIR ?? process.cwd();
+  const projectName = process.env.AUSLAW_PROJECT_NAME ?? path.basename(cacheDir);
+  const sourcesDir = process.env.AUSLAW_SOURCES_DIR ?? path.join(cacheDir, "sources");
+
   return {
     austlii: {
       searchBase:
@@ -61,6 +79,14 @@ export function loadConfig(): Config {
       maxSearchLimit: parseInt(process.env.MAX_SEARCH_LIMIT || "50", 10),
       outputFormat: process.env.DEFAULT_OUTPUT_FORMAT || "json",
       sortBy: process.env.DEFAULT_SORT_BY || "auto",
+    },
+    cache: {
+      dir: cacheDir,
+      projectName,
+    },
+    sources: {
+      dir: sourcesDir,
+      fetchByDefault: process.env.AUSLAW_FETCH_SOURCES !== "false",
     },
   };
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,8 +11,8 @@ export const NEUTRAL_CITATION_PATTERN = /\[(\d{4})\]\s*([A-Za-z0-9]+)\s*(\d+)/;
 
 /** Regular expressions for reported citations */
 export const REPORTED_CITATION_PATTERNS = [
-  /\((\d{4})\)\s+(\d+)\s+([A-Z]{2,6})\s+(\d+)/, // (2024) 350 ALR 123
-  /\[(\d{4})\]\s+(\d+)\s+([A-Z]{2,6})\s+(\d+)/, // [2024] 1 NZLR 456
+  /\((\d{4})\)\s+(\d+)\s+([A-Za-z]{2,8})\s+(\d+)/, // (2024) 350 ALR 123 / (1992) 175 CLR 1 / (2010) 19 FamLR 1
+  /\[(\d{4})\]\s+(\d+)\s+([A-Za-z]{2,8})\s+(\d+)/, // [2024] 1 NZLR 456 / [1992] 1 QdR 1
 ] as const;
 
 export const REPORTERS: Record<string, string> = {
@@ -96,3 +96,9 @@ export const MAX_CONTENT_LENGTH = 50 * 1024 * 1024;
 
 /** Maximum number of jade.io articles to resolve concurrently during search */
 export const MAX_JADE_RESOLUTIONS = 5;
+
+/** Version of the local citation cache schema — increment on breaking changes */
+export const AUSLAW_CACHE_VERSION = 1;
+
+/** Subdirectory name for the local cache within the project directory */
+export const AUSLAW_CACHE_DIR_NAME = ".auslaw";

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./services/citation-cache.js";
 import { storeSource, checkSourceFreshness } from "./services/source-store.js";
 import { config } from "./config.js";
+import { AUSLAW_CACHE_DIR_NAME } from "./constants.js";
 
 const formatEnum = z.enum(["json", "text", "markdown", "html"]).default("json");
 const jurisdictionEnum = z.enum([
@@ -157,7 +158,7 @@ function createMcpServer(): McpServer {
     {
       title: "Fetch Document Text",
       description:
-        "Fetch full text for a legislation or case URL (AustLII or jade.io), with OCR fallback for scanned PDFs. When AUSLAW_FETCH_SOURCES is not set to 'false', saves a local markdown copy to the sources directory and tracks HTTP cache headers for future freshness checks.",
+        "Fetch full text for a legislation or case URL (AustLII or jade.io), with OCR fallback for scanned PDFs. When a `citeKey` is supplied and AUSLAW_FETCH_SOURCES is not set to 'false', also saves a local markdown copy to the sources directory and updates the cache entry's HTTP freshness headers. Without `citeKey`, only the document text is returned.",
       inputSchema: fetchDocumentShape,
     },
     async (rawInput) => {
@@ -647,14 +648,27 @@ function createMcpServer(): McpServer {
       const { document, outputPath } = exportBibliographyParser.parse(rawInput);
       const bibText = await exportBib(config.cache.dir, document);
 
-      const defaultPath = path.join(config.cache.dir, ".auslaw", `${config.cache.projectName}.bib`);
+      if (!bibText) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ path: null, entries: 0, bib: "" }, null, 2),
+            },
+          ],
+        };
+      }
+
+      const defaultPath = path.join(
+        config.cache.dir,
+        AUSLAW_CACHE_DIR_NAME,
+        `${config.cache.projectName}.bib`,
+      );
       const writePath = outputPath ?? defaultPath;
 
-      if (bibText) {
-        const { promises: fs } = await import("node:fs");
-        await fs.mkdir(path.dirname(writePath), { recursive: true });
-        await fs.writeFile(writePath, bibText, "utf-8");
-      }
+      const { promises: fs } = await import("node:fs");
+      await fs.mkdir(path.dirname(writePath), { recursive: true });
+      await fs.writeFile(writePath, bibText, "utf-8");
 
       return {
         content: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { createServer } from "node:http";
 import { z } from "zod";
 
+import path from "node:path";
 import { formatFetchResponse, formatSearchResults } from "./utils/formatter.js";
 import { fetchDocumentText } from "./services/fetcher.js";
 import { searchAustLii, type SearchResult } from "./services/austlii.js";
@@ -16,10 +17,20 @@ import {
 } from "./services/jade.js";
 import {
   formatAGLC4,
+  formatShortForm,
   validateCitation,
   parseCitation,
   generatePinpoint,
 } from "./services/citation.js";
+import {
+  upsertCitation,
+  getCitation,
+  listCitations,
+  exportBib,
+  updateSourceFields,
+} from "./services/citation-cache.js";
+import { storeSource, checkSourceFreshness } from "./services/source-store.js";
+import { config } from "./config.js";
 
 const formatEnum = z.enum(["json", "text", "markdown", "html"]).default("json");
 const jurisdictionEnum = z.enum([
@@ -132,6 +143,12 @@ function createMcpServer(): McpServer {
   const fetchDocumentShape = {
     url: z.string().url("URL must be valid."),
     format: formatEnum.optional(),
+    citeKey: z
+      .string()
+      .optional()
+      .describe(
+        "Cite key of an existing cache entry to associate with this fetch (updates source fields).",
+      ),
   };
   const fetchDocumentParser = z.object(fetchDocumentShape);
 
@@ -140,12 +157,31 @@ function createMcpServer(): McpServer {
     {
       title: "Fetch Document Text",
       description:
-        "Fetch full text for a legislation or case URL (AustLII or jade.io), with OCR fallback for scanned PDFs.",
+        "Fetch full text for a legislation or case URL (AustLII or jade.io), with OCR fallback for scanned PDFs. When AUSLAW_FETCH_SOURCES is not set to 'false', saves a local markdown copy to the sources directory and tracks HTTP cache headers for future freshness checks.",
       inputSchema: fetchDocumentShape,
     },
     async (rawInput) => {
-      const { url, format } = fetchDocumentParser.parse(rawInput);
+      const { url, format, citeKey } = fetchDocumentParser.parse(rawInput);
       const response = await fetchDocumentText(url);
+
+      // Auto-store source when enabled and a citeKey is provided or fetchByDefault is on
+      if (config.sources.fetchByDefault && citeKey) {
+        try {
+          const existing = await getCitation(config.cache.dir, citeKey);
+          const storeResult = await storeSource(citeKey, url, existing, config.sources.dir);
+          const relPath = path.relative(config.cache.dir, storeResult.path);
+          await updateSourceFields(config.cache.dir, citeKey, {
+            sourceFile: relPath,
+            contentHash: storeResult.contentHash,
+            sourceFetchedAt: new Date().toISOString(),
+            sourceEtag: storeResult.etag,
+            sourceLastModified: storeResult.lastModified,
+          });
+        } catch {
+          // Source storage is best-effort — don't fail the fetch
+        }
+      }
+
       return formatFetchResponse(response, format ?? "json");
     },
   );
@@ -412,6 +448,414 @@ function createMcpServer(): McpServer {
         ),
       ];
       return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    },
+  );
+
+  // ── cache_citation ────────────────────────────────────────────────────────
+  const cacheCitationShape = {
+    title: z.string().min(1).describe("Case name, e.g. 'Mabo v Queensland (No 2)'"),
+    neutralCitation: z.string().optional().describe("Neutral citation, e.g. '[1992] HCA 23'"),
+    reportedCitation: z.string().optional().describe("Reported citation, e.g. '(1992) 175 CLR 1'"),
+    url: z.string().url().describe("Primary source URL (AustLII or jade.io)"),
+    type: z
+      .enum(["case", "legislation", "secondary", "treaty"])
+      .default("case")
+      .describe("Source type"),
+    jurisdiction: z.string().optional(),
+    year: z.number().int().optional().describe("Decision year"),
+    court: z.string().optional().describe("Court code, e.g. 'HCA'"),
+    keywords: z.array(z.string()).optional(),
+    summary: z.string().optional().describe("Brief abstract of the source"),
+    document: z
+      .string()
+      .optional()
+      .describe("Logical document name this citation belongs to, e.g. 'essay-chapter-3'"),
+    footnoteNumber: z
+      .number()
+      .int()
+      .optional()
+      .describe("Footnote number where this citation first appears in `document`"),
+    pinpoint: z
+      .string()
+      .optional()
+      .describe("Pinpoint to include in the AGLC4 full form, e.g. '[20]' or '401 to 407'"),
+    style: z
+      .enum(["neutral", "reported", "combined"])
+      .default("combined")
+      .describe("Which citation components to include in aglc4Full"),
+  };
+  const cacheCitationParser = z.object(cacheCitationShape);
+
+  server.registerTool(
+    "cache_citation",
+    {
+      title: "Cache Citation",
+      description:
+        "Store or update a citation in the local project cache. Assigns a biblatex-compatible cite key on first use. Returns the cite key and canonical AGLC4 string.",
+      inputSchema: cacheCitationShape,
+    },
+    async (rawInput) => {
+      const {
+        title,
+        neutralCitation,
+        reportedCitation,
+        url,
+        type,
+        jurisdiction,
+        year,
+        court,
+        keywords,
+        summary,
+        document,
+        footnoteNumber,
+        pinpoint,
+        style,
+      } = cacheCitationParser.parse(rawInput);
+
+      const aglc4Full = formatAGLC4({
+        title,
+        neutralCitation: style !== "reported" ? neutralCitation : undefined,
+        reportedCitation: style !== "neutral" ? reportedCitation : undefined,
+        pinpoint,
+      });
+
+      const citeKey = await upsertCitation(config.cache.dir, {
+        title,
+        neutralCitation,
+        reportedCitation,
+        aglc4Full,
+        url,
+        type,
+        jurisdiction,
+        year,
+        court,
+        keywords,
+        summary,
+        document,
+        footnoteNumber,
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ citeKey, aglc4Full, cached: true }, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // ── get_cached_citation ───────────────────────────────────────────────────
+  const getCachedCitationShape = {
+    query: z
+      .string()
+      .min(1)
+      .describe(
+        "Cite key (e.g. 'mabo1992'), AGLC4 citation string, neutral citation, or case title",
+      ),
+  };
+  const getCachedCitationParser = z.object(getCachedCitationShape);
+
+  server.registerTool(
+    "get_cached_citation",
+    {
+      title: "Get Cached Citation",
+      description:
+        "Retrieve a citation from the local cache without any network calls. Looks up by cite key, AGLC4 full string, neutral citation, or case title.",
+      inputSchema: getCachedCitationShape,
+    },
+    async (rawInput) => {
+      const { query } = getCachedCitationParser.parse(rawInput);
+      const entry = await getCitation(config.cache.dir, query);
+      if (!entry) {
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ found: false, query }) }],
+        };
+      }
+      return {
+        content: [
+          { type: "text" as const, text: JSON.stringify({ found: true, ...entry }, null, 2) },
+        ],
+      };
+    },
+  );
+
+  // ── list_bibliography ─────────────────────────────────────────────────────
+  const listBibliographyShape = {
+    document: z
+      .string()
+      .optional()
+      .describe("Filter to citations used in this document. Omit for all project citations."),
+    format: formatEnum.optional(),
+  };
+  const listBibliographyParser = z.object(listBibliographyShape);
+
+  server.registerTool(
+    "list_bibliography",
+    {
+      title: "List Bibliography",
+      description:
+        "List all cached citations for this project, optionally filtered to a specific document.",
+      inputSchema: listBibliographyShape,
+    },
+    async (rawInput) => {
+      const { document, format } = listBibliographyParser.parse(rawInput);
+      const entries = await listCitations(config.cache.dir, document);
+      const fmt = format ?? "json";
+
+      if (fmt === "json") {
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(entries, null, 2) }],
+          structuredContent: { format: "json", data: entries },
+        };
+      }
+      if (fmt === "markdown") {
+        const lines = entries.map((e) => `- **${e.citeKey}** — ${e.aglc4Full}`);
+        return { content: [{ type: "text" as const, text: lines.join("\n") || "(empty)" }] };
+      }
+      // text / html
+      const lines = entries.map((e, i) => `${i + 1}. [${e.citeKey}] ${e.aglc4Full}`);
+      return { content: [{ type: "text" as const, text: lines.join("\n") || "(empty)" }] };
+    },
+  );
+
+  // ── export_bibliography ───────────────────────────────────────────────────
+  const exportBibliographyShape = {
+    document: z
+      .string()
+      .optional()
+      .describe("Export only citations used in this document. Omit for all project citations."),
+    outputPath: z
+      .string()
+      .optional()
+      .describe(
+        "Write the .bib file to this absolute path. Defaults to <cacheDir>/<projectName>.bib",
+      ),
+  };
+  const exportBibliographyParser = z.object(exportBibliographyShape);
+
+  server.registerTool(
+    "export_bibliography",
+    {
+      title: "Export Bibliography (.bib)",
+      description:
+        "Export cached citations as a BibLaTeX .bib file. Returns the bib text and the path where it was written.",
+      inputSchema: exportBibliographyShape,
+    },
+    async (rawInput) => {
+      const { document, outputPath } = exportBibliographyParser.parse(rawInput);
+      const bibText = await exportBib(config.cache.dir, document);
+
+      const defaultPath = path.join(config.cache.dir, ".auslaw", `${config.cache.projectName}.bib`);
+      const writePath = outputPath ?? defaultPath;
+
+      if (bibText) {
+        const { promises: fs } = await import("node:fs");
+        await fs.mkdir(path.dirname(writePath), { recursive: true });
+        await fs.writeFile(writePath, bibText, "utf-8");
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                path: writePath,
+                entries: bibText.split("\n\n").filter(Boolean).length,
+                bib: bibText,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+
+  // ── format_short_citation ─────────────────────────────────────────────────
+  const formatShortCitationShape = {
+    title: z
+      .string()
+      .min(1)
+      .describe("The abbreviated case name chosen at first reference, e.g. 'Mabo'"),
+    mode: z
+      .enum(["short", "ibid", "subsequent"])
+      .default("short")
+      .describe(
+        "short = plain short form; ibid = Ibid (back-to-back same source); subsequent = title (n X)",
+      ),
+    footnoteRef: z
+      .number()
+      .int()
+      .optional()
+      .describe("Footnote number of first citation — required for 'subsequent' mode"),
+    pinpointPara: z.number().int().optional().describe("Paragraph pinpoint number, e.g. 20 → [20]"),
+    pinpointPage: z.number().int().optional().describe("Page pinpoint number, e.g. 401"),
+  };
+  const formatShortCitationParser = z.object(formatShortCitationShape);
+
+  server.registerTool(
+    "format_short_citation",
+    {
+      title: "Format Short-Form Citation",
+      description:
+        "Format an AGLC4-compliant short-form, Ibid, or subsequent reference. Use 'ibid' when citing the same source as the immediately preceding footnote; 'subsequent' for later references (requires footnoteRef).",
+      inputSchema: formatShortCitationShape,
+    },
+    async (rawInput) => {
+      const { title, mode, footnoteRef, pinpointPara, pinpointPage } =
+        formatShortCitationParser.parse(rawInput);
+
+      const pinpoint =
+        pinpointPara !== undefined
+          ? { type: "para" as const, n: pinpointPara }
+          : pinpointPage !== undefined
+            ? { type: "page" as const, n: pinpointPage }
+            : undefined;
+
+      const result = formatShortForm({ title, mode, footnoteRef, pinpoint });
+      return { content: [{ type: "text" as const, text: result }] };
+    },
+  );
+
+  // ── check_source_freshness ────────────────────────────────────────────────
+  const checkSourceFreshnessShape = {
+    citeKey: z.string().min(1).describe("Cite key of a cached citation, e.g. 'mabo1992'"),
+  };
+  const checkSourceFreshnessParser = z.object(checkSourceFreshnessShape);
+
+  server.registerTool(
+    "check_source_freshness",
+    {
+      title: "Check Source Freshness",
+      description:
+        "Check whether the locally cached source file for a citation is still current. Issues a conditional HEAD request using the stored ETag/Last-Modified. If the remote source is newer, downloads and updates the local copy automatically.",
+      inputSchema: checkSourceFreshnessShape,
+    },
+    async (rawInput) => {
+      const { citeKey } = checkSourceFreshnessParser.parse(rawInput);
+      const entry = await getCitation(config.cache.dir, citeKey);
+
+      if (!entry) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: `No cached citation found for key: ${citeKey}` }),
+            },
+          ],
+        };
+      }
+
+      if (!entry.sourceEtag && !entry.sourceLastModified && !entry.contentHash) {
+        // No source ever fetched — download now
+        try {
+          const storeResult = await storeSource(citeKey, entry.url, null, config.sources.dir);
+          const relPath = path.relative(config.cache.dir, storeResult.path);
+          await updateSourceFields(config.cache.dir, citeKey, {
+            sourceFile: relPath,
+            contentHash: storeResult.contentHash,
+            sourceFetchedAt: new Date().toISOString(),
+            sourceEtag: storeResult.etag,
+            sourceLastModified: storeResult.lastModified,
+          });
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    fresh: false,
+                    changed: true,
+                    sourceFile: relPath,
+                    note: "Source downloaded for the first time",
+                  },
+                  null,
+                  2,
+                ),
+              },
+            ],
+          };
+        } catch (err) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  error: `Failed to download source: ${err instanceof Error ? err.message : String(err)}`,
+                }),
+              },
+            ],
+          };
+        }
+      }
+
+      const freshness = await checkSourceFreshness(
+        entry.url,
+        entry.sourceEtag,
+        entry.sourceLastModified,
+      );
+
+      if (!freshness.fresh) {
+        // Remote is newer — re-download
+        try {
+          const storeResult = await storeSource(citeKey, entry.url, entry, config.sources.dir);
+          const relPath = path.relative(config.cache.dir, storeResult.path);
+          await updateSourceFields(config.cache.dir, citeKey, {
+            sourceFile: relPath,
+            contentHash: storeResult.contentHash,
+            sourceFetchedAt: new Date().toISOString(),
+            sourceEtag: storeResult.etag,
+            sourceLastModified: storeResult.lastModified,
+          });
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  { fresh: false, changed: storeResult.changed, sourceFile: relPath },
+                  null,
+                  2,
+                ),
+              },
+            ],
+          };
+        } catch (err) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  error: `Failed to refresh source: ${err instanceof Error ? err.message : String(err)}`,
+                }),
+              },
+            ],
+          };
+        }
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                fresh: true,
+                changed: false,
+                sourceFile: entry.sourceFile,
+                lastChecked: new Date().toISOString(),
+                etag: freshness.etag ?? entry.sourceEtag,
+                lastModified: freshness.lastModified ?? entry.sourceLastModified,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
     },
   );
 

--- a/src/services/citation-cache.ts
+++ b/src/services/citation-cache.ts
@@ -104,7 +104,15 @@ export async function loadCache(cacheDir: string): Promise<CitationCache> {
   const cachePath = getCachePath(cacheDir);
   try {
     const raw = await fs.readFile(cachePath, "utf-8");
-    return JSON.parse(raw) as CitationCache;
+    const parsed = JSON.parse(raw) as CitationCache;
+    if (parsed.version !== undefined && parsed.version > AUSLAW_CACHE_VERSION) {
+      console.warn(
+        `auslaw-mcp: citation cache at ${cachePath} was written by a newer version ` +
+          `(schema v${parsed.version}, current v${AUSLAW_CACHE_VERSION}). ` +
+          `Some fields may be ignored. Update auslaw-mcp to avoid data loss.`,
+      );
+    }
+    return parsed;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return {
@@ -185,6 +193,11 @@ function formatBibEntry(entry: CachedCitation): string {
  * Add or update a citation entry.
  * Matches on neutralCitation, aglc4Full, or url — whichever is present.
  * Returns the citeKey assigned to the entry.
+ *
+ * Note: uses a load-mutate-save pattern with no file lock. Concurrent calls
+ * from the same process (e.g. parallel MCP tool invocations under HTTP
+ * transport) can silently lose each other's writes. Safe for the default
+ * single-client stdio transport.
  */
 export async function upsertCitation(cacheDir: string, input: UpsertInput): Promise<string> {
   const cache = await loadCache(cacheDir);
@@ -295,6 +308,9 @@ export async function exportBib(cacheDir: string, document?: string): Promise<st
 /**
  * Update source-related fields on an existing cache entry.
  * Used by the source-store after a successful fetch.
+ *
+ * Note: same load-mutate-save limitation as upsertCitation — not safe for
+ * concurrent writes.
  */
 export async function updateSourceFields(
   cacheDir: string,

--- a/src/services/citation-cache.ts
+++ b/src/services/citation-cache.ts
@@ -1,0 +1,316 @@
+/**
+ * AusLaw MCP - Local citation cache
+ *
+ * Persists citations as a JSON file in <cacheDir>/.auslaw/citations.json.
+ * Each entry is embedding-ready: metadata fields are rich enough to attach
+ * a vector embedding later without a schema migration.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { AUSLAW_CACHE_VERSION, AUSLAW_CACHE_DIR_NAME } from "../constants.js";
+
+const CACHE_FILE_NAME = "citations.json";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface CachedCitation {
+  /** biblatex-compatible cite key, unique within this project. */
+  citeKey: string;
+  /** UUID for graph-edge references between entries. */
+  id: string;
+
+  // Core citation data
+  title: string;
+  neutralCitation?: string;
+  reportedCitation?: string;
+  /** Canonical AGLC4-formatted full citation string. */
+  aglc4Full: string;
+  /** Short form once the agent has assigned one (AGLC4 r 1.4.3). */
+  aglc4Short?: string;
+
+  // Source link
+  url: string;
+  /** Relative path from cacheDir, e.g. "sources/mabo1992.md". */
+  sourceFile?: string;
+  /** SHA-256 hex of source text — used for offline change detection. */
+  contentHash?: string;
+  sourceFetchedAt?: string;
+  /** HTTP ETag for conditional GET freshness checks. */
+  sourceEtag?: string;
+  /** HTTP Last-Modified for conditional GET freshness checks. */
+  sourceLastModified?: string;
+
+  // Classification — used as embedding metadata
+  type: "case" | "legislation" | "secondary" | "treaty";
+  jurisdiction?: string;
+  year?: number;
+  court?: string;
+  keywords?: string[];
+  summary?: string;
+
+  // Embedding slot — populated by a future kannon-2 / local-model integration
+  embedding?: number[];
+  embeddingModel?: string;
+
+  // Project tracking
+  /** Logical document IDs within this project that cite this source. */
+  documents: string[];
+  /** Maps document → footnote number of first citation in that document. */
+  footnoteNumbers: Record<string, number>;
+  addedAt: string;
+  updatedAt: string;
+
+  // biblatex export
+  bibType: "jurisdiction" | "misc" | "incollection" | "article";
+  bibFields: Record<string, string>;
+}
+
+export interface CitationCache {
+  version: number;
+  projectName: string;
+  entries: CachedCitation[];
+}
+
+export interface UpsertInput {
+  title: string;
+  neutralCitation?: string;
+  reportedCitation?: string;
+  aglc4Full: string;
+  url: string;
+  type?: "case" | "legislation" | "secondary" | "treaty";
+  jurisdiction?: string;
+  year?: number;
+  court?: string;
+  keywords?: string[];
+  summary?: string;
+  /** Logical document name to associate with this citation. */
+  document?: string;
+  /** Footnote number in `document` where this citation first appears. */
+  footnoteNumber?: number;
+}
+
+// ── Path helpers ──────────────────────────────────────────────────────────────
+
+function getCachePath(cacheDir: string): string {
+  return path.join(cacheDir, AUSLAW_CACHE_DIR_NAME, CACHE_FILE_NAME);
+}
+
+// ── Core I/O ──────────────────────────────────────────────────────────────────
+
+/** Load the citation cache, returning an empty cache if none exists yet. */
+export async function loadCache(cacheDir: string): Promise<CitationCache> {
+  const cachePath = getCachePath(cacheDir);
+  try {
+    const raw = await fs.readFile(cachePath, "utf-8");
+    return JSON.parse(raw) as CitationCache;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return {
+        version: AUSLAW_CACHE_VERSION,
+        projectName: path.basename(cacheDir),
+        entries: [],
+      };
+    }
+    throw err;
+  }
+}
+
+async function saveCache(cacheDir: string, cache: CitationCache): Promise<void> {
+  const cachePath = getCachePath(cacheDir);
+  await fs.mkdir(path.dirname(cachePath), { recursive: true });
+  await fs.writeFile(cachePath, JSON.stringify(cache, null, 2), "utf-8");
+}
+
+// ── Cite key generation ───────────────────────────────────────────────────────
+
+/**
+ * Generate a unique, biblatex-compatible cite key from a case title and year.
+ *
+ * Strategy: strip "v", "re", "(No N)", take the first significant word,
+ * append the year, then add a suffix letter on collision.
+ */
+export function generateCiteKey(title: string, year?: number, existing: string[] = []): string {
+  const stripped = title
+    .replace(/\s*\(No\.?\s*\d+\)/gi, "")
+    .split(/\s+v\s+/i)[0]!
+    .replace(/^(re|in re|ex parte)\s+/i, "")
+    .replace(/[^a-zA-Z0-9\s]/g, "")
+    .trim();
+
+  const firstWord = stripped.split(/\s+/)[0]?.toLowerCase() ?? "unknown";
+  const base = year ? `${firstWord}${year}` : firstWord;
+
+  if (!existing.includes(base)) return base;
+
+  for (const suffix of "abcdefghijklmnopqrstuvwxyz") {
+    const key = `${base}${suffix}`;
+    if (!existing.includes(key)) return key;
+  }
+
+  return `${base}${crypto.randomBytes(2).toString("hex")}`;
+}
+
+// ── biblatex helpers ──────────────────────────────────────────────────────────
+
+function buildBibFields(
+  entry: Omit<CachedCitation, "bibFields" | "bibType">,
+): Record<string, string> {
+  const fields: Record<string, string> = { title: entry.title };
+  if (entry.year !== undefined) fields["year"] = String(entry.year);
+  if (entry.neutralCitation) fields["citation"] = entry.neutralCitation;
+  if (entry.reportedCitation) fields["reporter"] = entry.reportedCitation;
+  if (entry.url) fields["url"] = entry.url;
+  if (entry.aglc4Full) fields["note"] = entry.aglc4Full;
+  if (entry.court) fields["court"] = entry.court;
+  if (entry.jurisdiction) fields["jurisdiction"] = entry.jurisdiction;
+  return fields;
+}
+
+function escapeBibValue(s: string): string {
+  return s.replace(/[{}]/g, (c) => `\\${c}`);
+}
+
+function formatBibEntry(entry: CachedCitation): string {
+  const lines = Object.entries(entry.bibFields)
+    .map(([k, v]) => `  ${k.padEnd(12)} = {${escapeBibValue(v)}}`)
+    .join(",\n");
+  return `@${entry.bibType}{${entry.citeKey},\n${lines}\n}`;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Add or update a citation entry.
+ * Matches on neutralCitation, aglc4Full, or url — whichever is present.
+ * Returns the citeKey assigned to the entry.
+ */
+export async function upsertCitation(cacheDir: string, input: UpsertInput): Promise<string> {
+  const cache = await loadCache(cacheDir);
+
+  const existing = cache.entries.find(
+    (e) =>
+      (input.neutralCitation && e.neutralCitation === input.neutralCitation) ||
+      e.aglc4Full === input.aglc4Full ||
+      e.url === input.url,
+  );
+
+  if (existing) {
+    existing.aglc4Full = input.aglc4Full;
+    existing.updatedAt = new Date().toISOString();
+    if (input.keywords?.length) {
+      existing.keywords = [...new Set([...(existing.keywords ?? []), ...input.keywords])];
+    }
+    if (input.summary) existing.summary = input.summary;
+    if (input.document && !existing.documents.includes(input.document)) {
+      existing.documents.push(input.document);
+    }
+    if (input.document && input.footnoteNumber !== undefined) {
+      existing.footnoteNumbers[input.document] = input.footnoteNumber;
+    }
+    existing.bibFields = buildBibFields(existing);
+    await saveCache(cacheDir, cache);
+    return existing.citeKey;
+  }
+
+  const existingKeys = cache.entries.map((e) => e.citeKey);
+  const citeKey = generateCiteKey(input.title, input.year, existingKeys);
+  const now = new Date().toISOString();
+
+  const entry: CachedCitation = {
+    citeKey,
+    id: crypto.randomUUID(),
+    title: input.title,
+    neutralCitation: input.neutralCitation,
+    reportedCitation: input.reportedCitation,
+    aglc4Full: input.aglc4Full,
+    url: input.url,
+    type: input.type ?? "case",
+    jurisdiction: input.jurisdiction,
+    year: input.year,
+    court: input.court,
+    keywords: input.keywords ?? [],
+    summary: input.summary,
+    documents: input.document ? [input.document] : [],
+    footnoteNumbers:
+      input.document && input.footnoteNumber !== undefined
+        ? { [input.document]: input.footnoteNumber }
+        : {},
+    addedAt: now,
+    updatedAt: now,
+    bibType: input.type === "case" || input.type === undefined ? "jurisdiction" : "misc",
+    bibFields: {},
+  };
+  entry.bibFields = buildBibFields(entry);
+
+  cache.entries.push(entry);
+  await saveCache(cacheDir, cache);
+  return citeKey;
+}
+
+/**
+ * Retrieve a cached citation by cite key, normalised AGLC4 string,
+ * neutral citation, or case title. Returns null if not found.
+ */
+export async function getCitation(
+  cacheDir: string,
+  keyOrCitation: string,
+): Promise<CachedCitation | null> {
+  const cache = await loadCache(cacheDir);
+  const q = keyOrCitation.replace(/\s+/g, " ").trim();
+  return (
+    cache.entries.find(
+      (e) =>
+        e.citeKey === q ||
+        e.aglc4Full === q ||
+        (e.neutralCitation && e.neutralCitation === q) ||
+        e.title === q,
+    ) ?? null
+  );
+}
+
+/**
+ * List all cached citations, optionally filtered to a specific document.
+ */
+export async function listCitations(
+  cacheDir: string,
+  document?: string,
+): Promise<CachedCitation[]> {
+  const cache = await loadCache(cacheDir);
+  if (!document) return cache.entries;
+  return cache.entries.filter((e) => e.documents.includes(document));
+}
+
+/**
+ * Export cached citations as a .bib string.
+ * Optionally filter to a single document.
+ */
+export async function exportBib(cacheDir: string, document?: string): Promise<string> {
+  const entries = await listCitations(cacheDir, document);
+  if (entries.length === 0) return "";
+  return entries.map(formatBibEntry).join("\n\n");
+}
+
+/**
+ * Update source-related fields on an existing cache entry.
+ * Used by the source-store after a successful fetch.
+ */
+export async function updateSourceFields(
+  cacheDir: string,
+  citeKey: string,
+  fields: {
+    sourceFile?: string;
+    contentHash?: string;
+    sourceFetchedAt?: string;
+    sourceEtag?: string;
+    sourceLastModified?: string;
+  },
+): Promise<void> {
+  const cache = await loadCache(cacheDir);
+  const entry = cache.entries.find((e) => e.citeKey === citeKey);
+  if (!entry) return;
+  Object.assign(entry, fields);
+  entry.updatedAt = new Date().toISOString();
+  await saveCache(cacheDir, cache);
+}

--- a/src/services/citation.ts
+++ b/src/services/citation.ts
@@ -11,6 +11,7 @@ import {
   NEUTRAL_CITATION_PATTERN,
   REPORTED_CITATION_PATTERNS,
   COURT_TO_AUSTLII_PATH,
+  REPORTERS,
 } from "../constants.js";
 import type { ParagraphBlock } from "./fetcher.js";
 
@@ -24,6 +25,7 @@ export interface AGLC4FormatInput {
   title: string;
   neutralCitation?: string;
   reportedCitation?: string;
+  /** Free-form pinpoint string, e.g. "[20]", "401", "[64] to [66]". */
   pinpoint?: string;
 }
 
@@ -34,7 +36,80 @@ export interface CitationValidationResult {
   message?: string;
 }
 
-const PINPOINT_PATTERN = /\bat\s+\[(\d+)\]/;
+/**
+ * Structured pinpoint reference for AGLC4 citations.
+ *
+ * Use `formatPinpointRef` to convert to the correct AGLC4 string fragment.
+ */
+export type Pinpoint =
+  | { type: "para"; n: number } // at [20]
+  | { type: "page"; n: number } // at 401
+  | { type: "paraRange"; from: number; to: number } // at [64] to [66]
+  | { type: "pageRange"; from: number; to: number } // at 401 to 407
+  | { type: "legis"; ref: string }; // s 5(2)(a)  reg 12  sch 1
+
+/** Convert a structured Pinpoint to the AGLC4 string fragment (without leading "at"). */
+export function formatPinpointRef(p: Pinpoint): string {
+  switch (p.type) {
+    case "para":
+      return `[${p.n}]`;
+    case "page":
+      return String(p.n);
+    case "paraRange":
+      return `[${p.from}] to [${p.to}]`;
+    case "pageRange":
+      return `${p.from} to ${p.to}`;
+    case "legis":
+      return p.ref;
+  }
+}
+
+/** Input to `formatShortForm`. */
+export interface ShortFormInput {
+  /** The abbreviated case name chosen at first reference. */
+  title: string;
+  pinpoint?: Pinpoint;
+  /** "short" = plain short form, "ibid" = Ibid, "subsequent" = title (n X). */
+  mode: "short" | "ibid" | "subsequent";
+  /** Footnote number of the first citation — required for "subsequent" mode. */
+  footnoteRef?: number;
+}
+
+/**
+ * Format an AGLC4-compliant short-form, Ibid, or subsequent reference.
+ *
+ * AGLC4 rr 1.4.3–1.4.5: Ibid for back-to-back same-source citations;
+ * author/case-name (n X) for later subsequent references.
+ */
+export function formatShortForm(input: ShortFormInput): string {
+  const pin = input.pinpoint ? ` ${formatPinpointRef(input.pinpoint)}` : "";
+  switch (input.mode) {
+    case "ibid":
+      return `Ibid${pin}`;
+    case "subsequent": {
+      const ref = input.footnoteRef !== undefined ? ` (n ${input.footnoteRef})` : "";
+      return `${input.title}${ref}${pin}`;
+    }
+    case "short":
+    default:
+      return `${input.title}${pin}`;
+  }
+}
+
+// Broad pinpoint patterns for parseCitation
+// Order matters — more specific patterns first
+const PINPOINT_PATTERNS = [
+  // Paragraph range: at [64] to [66]
+  /\bat\s+\[(\d+)\]\s+to\s+\[(\d+)\]/,
+  // Page range: at 401 to 407
+  /\bat\s+(\d+)\s+to\s+(\d+)(?!\])/,
+  // Paragraph: at [20]
+  /\bat\s+\[(\d+)\]/,
+  // Page number: at 401
+  /\bat\s+(\d+)(?!\])/,
+  // Legislation: at s 5(2)(a) / reg 12 / sch 1
+  /\bat\s+((?:ss?|reg|regs?|sch)\s+\S[^,;]*)/,
+] as const;
 
 export function parseCitation(text: string): ParsedCitation | null {
   const neutralMatch = text.match(NEUTRAL_CITATION_PATTERN);
@@ -42,7 +117,10 @@ export function parseCitation(text: string): ParsedCitation | null {
 
   for (const pattern of REPORTED_CITATION_PATTERNS) {
     const match = text.match(pattern);
-    if (match) {
+    if (match && match[3] && Object.prototype.hasOwnProperty.call(REPORTERS, match[3])) {
+      reportedCitations.push(match[0]);
+    } else if (match && match[3] && /^[A-Z]{2,8}$/.test(match[3])) {
+      // Accept uppercase-only reporters even if not in REPORTERS table
       reportedCitations.push(match[0]);
     }
   }
@@ -51,12 +129,37 @@ export function parseCitation(text: string): ParsedCitation | null {
     return null;
   }
 
-  const pinpointMatch = text.match(PINPOINT_PATTERN);
+  // Try each pinpoint pattern in order
+  let pinpoint: string | undefined;
+  const paraRangeMatch = text.match(PINPOINT_PATTERNS[0]);
+  if (paraRangeMatch?.[1] && paraRangeMatch[2]) {
+    pinpoint = `[${paraRangeMatch[1]}] to [${paraRangeMatch[2]}]`;
+  } else {
+    const pageRangeMatch = text.match(PINPOINT_PATTERNS[1]);
+    if (pageRangeMatch?.[1] && pageRangeMatch[2]) {
+      pinpoint = `${pageRangeMatch[1]} to ${pageRangeMatch[2]}`;
+    } else {
+      const paraMatch = text.match(PINPOINT_PATTERNS[2]);
+      if (paraMatch?.[1]) {
+        pinpoint = `[${paraMatch[1]}]`;
+      } else {
+        const pageMatch = text.match(PINPOINT_PATTERNS[3]);
+        if (pageMatch?.[1]) {
+          pinpoint = pageMatch[1];
+        } else {
+          const legisMatch = text.match(PINPOINT_PATTERNS[4]);
+          if (legisMatch?.[1]) {
+            pinpoint = legisMatch[1].trim();
+          }
+        }
+      }
+    }
+  }
 
   return {
     neutralCitation: neutralMatch?.[0],
     reportedCitations,
-    pinpoint: pinpointMatch ? `[${pinpointMatch[1]}]` : undefined,
+    pinpoint,
   };
 }
 
@@ -90,7 +193,19 @@ export function isValidNeutralCitation(s: string): boolean {
 }
 
 export function isValidReportedCitation(s: string): boolean {
-  return REPORTED_CITATION_PATTERNS.some((pattern) => pattern.test(s));
+  for (const pattern of REPORTED_CITATION_PATTERNS) {
+    const match = s.match(pattern);
+    if (match && match[3]) {
+      // Accept if known reporter OR all-uppercase (standard abbreviation)
+      if (
+        Object.prototype.hasOwnProperty.call(REPORTERS, match[3]) ||
+        /^[A-Z]{2,8}$/.test(match[3])
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 export function normaliseCitation(s: string): string {

--- a/src/services/source-store.ts
+++ b/src/services/source-store.ts
@@ -1,0 +1,135 @@
+/**
+ * AusLaw MCP - Source store
+ *
+ * Downloads and persists source documents as local markdown files.
+ * Uses HTTP ETag / Last-Modified for conditional-GET freshness checks so that
+ * re-fetching skips the network when the primary source has not changed.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import axios from "axios";
+import { fetchDocumentText } from "./fetcher.js";
+import { assertFetchableUrl } from "../utils/url-guard.js";
+
+export interface FreshnessResult {
+  /** True when the server confirmed the local copy is current (HTTP 304). */
+  fresh: boolean;
+  /** ETag from the server response (may be updated even on 304). */
+  etag?: string;
+  /** Last-Modified from the server response. */
+  lastModified?: string;
+}
+
+export interface StoreSourceResult {
+  /** Absolute path of the written (or already-current) file. */
+  path: string;
+  /** True when the file content was updated or created during this call. */
+  changed: boolean;
+  etag?: string;
+  lastModified?: string;
+  contentHash: string;
+}
+
+/**
+ * Issue a conditional HEAD request to check whether the local copy of a
+ * source document is still current.
+ *
+ * Returns `fresh: true` (HTTP 304) or `fresh: false` (HTTP 200 / error).
+ * Network errors are treated as stale so the caller falls back to re-fetching.
+ */
+export async function checkSourceFreshness(
+  url: string,
+  etag?: string,
+  lastModified?: string,
+): Promise<FreshnessResult> {
+  try {
+    assertFetchableUrl(url);
+    const headers: Record<string, string> = {};
+    if (etag) headers["If-None-Match"] = etag;
+    if (lastModified) headers["If-Modified-Since"] = lastModified;
+
+    const response = await axios.head(url, {
+      headers,
+      validateStatus: (s) => s === 200 || s === 304,
+      timeout: 10_000,
+    });
+
+    return {
+      fresh: response.status === 304,
+      etag: (response.headers["etag"] as string) ?? undefined,
+      lastModified: (response.headers["last-modified"] as string) ?? undefined,
+    };
+  } catch {
+    // Network or status errors — treat as stale so the caller re-fetches
+    return { fresh: false };
+  }
+}
+
+/**
+ * Download a source document and save it as a markdown file under `sourcesDir`.
+ *
+ * Freshness check flow:
+ * 1. If `cached` provides ETag/Last-Modified, issue a conditional HEAD first.
+ *    HTTP 304 → local copy is current; return without re-downloading.
+ * 2. Otherwise fetch full content, compute SHA-256, compare to `cached.contentHash`.
+ *    Only write to disk when the hash differs.
+ * 3. Issue a follow-up HEAD to capture current ETag/Last-Modified for the
+ *    next freshness check (skipped when the primary URL does not return them).
+ *
+ * @returns Path of the file, whether it changed, and HTTP cache headers.
+ */
+export async function storeSource(
+  citeKey: string,
+  url: string,
+  cached: {
+    contentHash?: string;
+    sourceEtag?: string;
+    sourceLastModified?: string;
+  } | null,
+  sourcesDir: string,
+): Promise<StoreSourceResult> {
+  const filePath = path.join(sourcesDir, `${citeKey}.md`);
+
+  // Freshness check when we have prior ETag or Last-Modified
+  if (cached?.sourceEtag || cached?.sourceLastModified) {
+    const freshness = await checkSourceFreshness(url, cached.sourceEtag, cached.sourceLastModified);
+    if (freshness.fresh && cached.contentHash) {
+      return {
+        path: filePath,
+        changed: false,
+        etag: freshness.etag ?? cached.sourceEtag,
+        lastModified: freshness.lastModified ?? cached.sourceLastModified,
+        contentHash: cached.contentHash,
+      };
+    }
+  }
+
+  // Full content fetch
+  const doc = await fetchDocumentText(url);
+  const text = doc.text;
+  const contentHash = crypto.createHash("sha256").update(text, "utf-8").digest("hex");
+  const changed = cached?.contentHash !== contentHash;
+
+  if (changed) {
+    await fs.mkdir(sourcesDir, { recursive: true });
+    const markdown = `> Source: ${url}\n\n${text}`;
+    await fs.writeFile(filePath, markdown, "utf-8");
+  }
+
+  // Attempt HEAD to capture ETag/Last-Modified for future freshness checks.
+  // Non-fatal — many AustLII responses do not carry these headers.
+  let etag: string | undefined;
+  let lastModified: string | undefined;
+  try {
+    assertFetchableUrl(url);
+    const headResp = await axios.head(url, { timeout: 10_000 });
+    etag = (headResp.headers["etag"] as string) ?? undefined;
+    lastModified = (headResp.headers["last-modified"] as string) ?? undefined;
+  } catch {
+    // Non-fatal
+  }
+
+  return { path: filePath, changed, etag, lastModified, contentHash };
+}

--- a/src/test/unit/citation-cache.test.ts
+++ b/src/test/unit/citation-cache.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Hoist mock so vi.mock factory can reference it
+const mockFs = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  mkdir: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  promises: mockFs,
+}));
+
+import {
+  generateCiteKey,
+  loadCache,
+  upsertCitation,
+  getCitation,
+  listCitations,
+  exportBib,
+  updateSourceFields,
+} from "../../services/citation-cache.js";
+
+const CACHE_DIR = "/test/project";
+
+function makeEntry(overrides = {}) {
+  return {
+    citeKey: "mabo1992",
+    id: "test-uuid",
+    title: "Mabo v Queensland (No 2)",
+    neutralCitation: "[1992] HCA 23",
+    reportedCitation: "(1992) 175 CLR 1",
+    aglc4Full: "Mabo v Queensland (No 2) [1992] HCA 23, (1992) 175 CLR 1",
+    url: "https://www.austlii.edu.au/cgi-bin/viewdoc/au/cases/cth/HCA/1992/23.html",
+    type: "case",
+    jurisdiction: "cth",
+    year: 1992,
+    court: "HCA",
+    keywords: [],
+    documents: [],
+    footnoteNumbers: {},
+    addedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    bibType: "jurisdiction",
+    bibFields: {
+      title: "Mabo v Queensland (No 2)",
+      year: "1992",
+      citation: "[1992] HCA 23",
+      reporter: "(1992) 175 CLR 1",
+      url: "https://www.austlii.edu.au/cgi-bin/viewdoc/au/cases/cth/HCA/1992/23.html",
+      note: "Mabo v Queensland (No 2) [1992] HCA 23, (1992) 175 CLR 1",
+      court: "HCA",
+      jurisdiction: "cth",
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFs.mkdir.mockResolvedValue(undefined);
+  mockFs.writeFile.mockResolvedValue(undefined);
+});
+
+describe("generateCiteKey", () => {
+  it("extracts first word and appends year", () => {
+    expect(generateCiteKey("Mabo v Queensland (No 2)", 1992)).toBe("mabo1992");
+  });
+
+  it("strips (No N) suffix", () => {
+    expect(generateCiteKey("Mabo v Queensland (No 2)", 1992, [])).toBe("mabo1992");
+  });
+
+  it("handles 'Re' prefix", () => {
+    expect(generateCiteKey("Re Smith", 2020)).toBe("smith2020");
+  });
+
+  it("handles 'Ex parte' prefix", () => {
+    expect(generateCiteKey("Ex parte Jones", 2010)).toBe("jones2010");
+  });
+
+  it("appends suffix letter on collision", () => {
+    const key = generateCiteKey("Mabo v Queensland (No 2)", 1992, ["mabo1992"]);
+    expect(key).toBe("mabo1992a");
+  });
+
+  it("cycles through suffix letters for multiple collisions", () => {
+    const key = generateCiteKey("Mabo v Queensland (No 2)", 1992, ["mabo1992", "mabo1992a"]);
+    expect(key).toBe("mabo1992b");
+  });
+
+  it("works without a year", () => {
+    expect(generateCiteKey("Smith v Jones")).toBe("smith");
+  });
+});
+
+describe("loadCache", () => {
+  it("returns empty cache when file does not exist", async () => {
+    const err = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    mockFs.readFile.mockRejectedValueOnce(err);
+    const cache = await loadCache(CACHE_DIR);
+    expect(cache.entries).toHaveLength(0);
+    expect(cache.version).toBe(1);
+  });
+
+  it("returns parsed cache when file exists", async () => {
+    const data = JSON.stringify({
+      version: 1,
+      projectName: "project",
+      entries: [makeEntry()],
+    });
+    mockFs.readFile.mockResolvedValueOnce(data);
+    const cache = await loadCache(CACHE_DIR);
+    expect(cache.entries).toHaveLength(1);
+    expect(cache.entries[0]?.citeKey).toBe("mabo1992");
+  });
+
+  it("re-throws non-ENOENT errors", async () => {
+    mockFs.readFile.mockRejectedValueOnce(new Error("EACCES"));
+    await expect(loadCache(CACHE_DIR)).rejects.toThrow("EACCES");
+  });
+});
+
+describe("upsertCitation", () => {
+  it("creates new entry on empty cache", async () => {
+    mockFs.readFile.mockRejectedValueOnce(Object.assign(new Error(), { code: "ENOENT" }));
+
+    const citeKey = await upsertCitation(CACHE_DIR, {
+      title: "Mabo v Queensland (No 2)",
+      neutralCitation: "[1992] HCA 23",
+      reportedCitation: "(1992) 175 CLR 1",
+      aglc4Full: "Mabo v Queensland (No 2) [1992] HCA 23, (1992) 175 CLR 1",
+      url: "https://www.austlii.edu.au/cgi-bin/viewdoc/au/cases/cth/HCA/1992/23.html",
+      year: 1992,
+    });
+
+    expect(citeKey).toBe("mabo1992");
+    expect(mockFs.writeFile).toHaveBeenCalledOnce();
+    const written = JSON.parse(mockFs.writeFile.mock.calls[0]![1] as string);
+    expect(written.entries).toHaveLength(1);
+    expect(written.entries[0].citeKey).toBe("mabo1992");
+  });
+
+  it("updates existing entry without creating duplicate", async () => {
+    const existing = JSON.stringify({
+      version: 1,
+      projectName: "project",
+      entries: [makeEntry()],
+    });
+    mockFs.readFile.mockResolvedValueOnce(existing);
+
+    const citeKey = await upsertCitation(CACHE_DIR, {
+      title: "Mabo v Queensland (No 2)",
+      neutralCitation: "[1992] HCA 23",
+      aglc4Full: "Mabo v Queensland (No 2) [1992] HCA 23 at [20]",
+      url: "https://www.austlii.edu.au/cgi-bin/viewdoc/au/cases/cth/HCA/1992/23.html",
+    });
+
+    expect(citeKey).toBe("mabo1992");
+    const written = JSON.parse(mockFs.writeFile.mock.calls[0]![1] as string);
+    expect(written.entries).toHaveLength(1);
+    expect(written.entries[0].aglc4Full).toBe("Mabo v Queensland (No 2) [1992] HCA 23 at [20]");
+  });
+
+  it("adds document to documents array on first association", async () => {
+    mockFs.readFile.mockRejectedValueOnce(Object.assign(new Error(), { code: "ENOENT" }));
+
+    await upsertCitation(CACHE_DIR, {
+      title: "Mabo v Queensland (No 2)",
+      neutralCitation: "[1992] HCA 23",
+      aglc4Full: "Mabo v Queensland (No 2) [1992] HCA 23",
+      url: "https://example.com",
+      document: "chapter-3",
+      footnoteNumber: 5,
+    });
+
+    const written = JSON.parse(mockFs.writeFile.mock.calls[0]![1] as string);
+    expect(written.entries[0].documents).toContain("chapter-3");
+    expect(written.entries[0].footnoteNumbers["chapter-3"]).toBe(5);
+  });
+
+  it("does not duplicate documents array entry", async () => {
+    const existing = JSON.stringify({
+      version: 1,
+      projectName: "project",
+      entries: [makeEntry({ documents: ["chapter-3"] })],
+    });
+    mockFs.readFile.mockResolvedValueOnce(existing);
+
+    await upsertCitation(CACHE_DIR, {
+      title: "Mabo v Queensland (No 2)",
+      neutralCitation: "[1992] HCA 23",
+      aglc4Full: "Mabo v Queensland (No 2) [1992] HCA 23",
+      url: "https://www.austlii.edu.au/cgi-bin/viewdoc/au/cases/cth/HCA/1992/23.html",
+      document: "chapter-3",
+    });
+
+    const written = JSON.parse(mockFs.writeFile.mock.calls[0]![1] as string);
+    expect(written.entries[0].documents.filter((d: string) => d === "chapter-3")).toHaveLength(1);
+  });
+});
+
+describe("getCitation", () => {
+  it("finds entry by citeKey", async () => {
+    mockFs.readFile.mockResolvedValueOnce(
+      JSON.stringify({ version: 1, projectName: "p", entries: [makeEntry()] }),
+    );
+    const result = await getCitation(CACHE_DIR, "mabo1992");
+    expect(result?.citeKey).toBe("mabo1992");
+  });
+
+  it("finds entry by neutralCitation", async () => {
+    mockFs.readFile.mockResolvedValueOnce(
+      JSON.stringify({ version: 1, projectName: "p", entries: [makeEntry()] }),
+    );
+    const result = await getCitation(CACHE_DIR, "[1992] HCA 23");
+    expect(result?.citeKey).toBe("mabo1992");
+  });
+
+  it("finds entry by aglc4Full string", async () => {
+    mockFs.readFile.mockResolvedValueOnce(
+      JSON.stringify({ version: 1, projectName: "p", entries: [makeEntry()] }),
+    );
+    const result = await getCitation(
+      CACHE_DIR,
+      "Mabo v Queensland (No 2) [1992] HCA 23, (1992) 175 CLR 1",
+    );
+    expect(result?.citeKey).toBe("mabo1992");
+  });
+
+  it("returns null when not found", async () => {
+    mockFs.readFile.mockResolvedValueOnce(
+      JSON.stringify({ version: 1, projectName: "p", entries: [] }),
+    );
+    const result = await getCitation(CACHE_DIR, "unknown");
+    expect(result).toBeNull();
+  });
+});
+
+describe("listCitations", () => {
+  it("returns all entries when no document filter", async () => {
+    mockFs.readFile.mockResolvedValueOnce(
+      JSON.stringify({
+        version: 1,
+        projectName: "p",
+        entries: [
+          makeEntry({ documents: ["doc-a"] }),
+          makeEntry({ citeKey: "telstra2010", title: "Telstra", documents: ["doc-b"] }),
+        ],
+      }),
+    );
+    const entries = await listCitations(CACHE_DIR);
+    expect(entries).toHaveLength(2);
+  });
+
+  it("filters by document", async () => {
+    mockFs.readFile.mockResolvedValueOnce(
+      JSON.stringify({
+        version: 1,
+        projectName: "p",
+        entries: [
+          makeEntry({ documents: ["doc-a"] }),
+          makeEntry({ citeKey: "telstra2010", title: "Telstra", documents: ["doc-b"] }),
+        ],
+      }),
+    );
+    const entries = await listCitations(CACHE_DIR, "doc-a");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.citeKey).toBe("mabo1992");
+  });
+});
+
+describe("exportBib", () => {
+  it("returns empty string for empty cache", async () => {
+    mockFs.readFile.mockRejectedValueOnce(Object.assign(new Error(), { code: "ENOENT" }));
+    const bib = await exportBib(CACHE_DIR);
+    expect(bib).toBe("");
+  });
+
+  it("exports @jurisdiction entry for case type", async () => {
+    mockFs.readFile.mockResolvedValueOnce(
+      JSON.stringify({ version: 1, projectName: "p", entries: [makeEntry()] }),
+    );
+    const bib = await exportBib(CACHE_DIR);
+    expect(bib).toContain("@jurisdiction{mabo1992,");
+    expect(bib).toContain("title");
+    expect(bib).toContain("Mabo v Queensland (No 2)");
+  });
+
+  it("exports @misc for secondary sources", async () => {
+    const entry = makeEntry({ bibType: "misc", citeKey: "bowrey2012" });
+    mockFs.readFile.mockResolvedValueOnce(
+      JSON.stringify({ version: 1, projectName: "p", entries: [entry] }),
+    );
+    const bib = await exportBib(CACHE_DIR);
+    expect(bib).toContain("@misc{bowrey2012,");
+  });
+
+  it("exports multiple entries separated by blank lines", async () => {
+    mockFs.readFile.mockResolvedValueOnce(
+      JSON.stringify({
+        version: 1,
+        projectName: "p",
+        entries: [makeEntry(), makeEntry({ citeKey: "telstra2010", title: "Telstra Corp Ltd" })],
+      }),
+    );
+    const bib = await exportBib(CACHE_DIR);
+    expect(bib).toContain("@jurisdiction{mabo1992,");
+    expect(bib).toContain("@jurisdiction{telstra2010,");
+    // Two entries separated by blank line
+    expect(bib).toMatch(/}\n\n@/);
+  });
+
+  it("filters by document", async () => {
+    mockFs.readFile.mockResolvedValueOnce(
+      JSON.stringify({
+        version: 1,
+        projectName: "p",
+        entries: [
+          makeEntry({ documents: ["doc-a"] }),
+          makeEntry({ citeKey: "telstra2010", title: "Telstra", documents: ["doc-b"] }),
+        ],
+      }),
+    );
+    const bib = await exportBib(CACHE_DIR, "doc-a");
+    expect(bib).toContain("mabo1992");
+    expect(bib).not.toContain("telstra2010");
+  });
+});
+
+describe("updateSourceFields", () => {
+  it("updates sourceFile, contentHash, and freshness fields", async () => {
+    mockFs.readFile.mockResolvedValueOnce(
+      JSON.stringify({ version: 1, projectName: "p", entries: [makeEntry()] }),
+    );
+    await updateSourceFields(CACHE_DIR, "mabo1992", {
+      sourceFile: "sources/mabo1992.md",
+      contentHash: "abc123",
+      sourceFetchedAt: "2026-01-01T00:00:00.000Z",
+      sourceEtag: '"etag-value"',
+      sourceLastModified: "Wed, 01 Jan 2026 00:00:00 GMT",
+    });
+    const written = JSON.parse(mockFs.writeFile.mock.calls[0]![1] as string);
+    const entry = written.entries[0];
+    expect(entry.sourceFile).toBe("sources/mabo1992.md");
+    expect(entry.contentHash).toBe("abc123");
+    expect(entry.sourceEtag).toBe('"etag-value"');
+  });
+
+  it("does nothing when citeKey not found", async () => {
+    mockFs.readFile.mockResolvedValueOnce(
+      JSON.stringify({ version: 1, projectName: "p", entries: [] }),
+    );
+    await updateSourceFields(CACHE_DIR, "nonexistent", { contentHash: "x" });
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/unit/citation.test.ts
+++ b/src/test/unit/citation.test.ts
@@ -3,12 +3,15 @@ import axios from "axios";
 import {
   parseCitation,
   formatAGLC4,
+  formatPinpointRef,
+  formatShortForm,
   isValidNeutralCitation,
   isValidReportedCitation,
   shortFormAGLC4,
   normaliseCitation,
   validateCitation,
   generatePinpoint,
+  type Pinpoint,
 } from "../../services/citation.js";
 import type { ParagraphBlock } from "../../services/fetcher.js";
 
@@ -185,5 +188,123 @@ describe("generatePinpoint", () => {
   it("phrase match is case-insensitive", () => {
     const result = generatePinpoint(paragraphs, { phrase: "DUTY OF CARE" });
     expect(result?.paragraphNumber).toBe(2);
+  });
+});
+
+describe("formatPinpointRef", () => {
+  it("formats paragraph pinpoint", () => {
+    const p: Pinpoint = { type: "para", n: 20 };
+    expect(formatPinpointRef(p)).toBe("[20]");
+  });
+
+  it("formats page pinpoint", () => {
+    const p: Pinpoint = { type: "page", n: 401 };
+    expect(formatPinpointRef(p)).toBe("401");
+  });
+
+  it("formats paragraph range", () => {
+    const p: Pinpoint = { type: "paraRange", from: 64, to: 66 };
+    expect(formatPinpointRef(p)).toBe("[64] to [66]");
+  });
+
+  it("formats page range", () => {
+    const p: Pinpoint = { type: "pageRange", from: 401, to: 407 };
+    expect(formatPinpointRef(p)).toBe("401 to 407");
+  });
+
+  it("formats legislation pinpoint", () => {
+    const p: Pinpoint = { type: "legis", ref: "s 5(2)(a)" };
+    expect(formatPinpointRef(p)).toBe("s 5(2)(a)");
+  });
+});
+
+describe("formatShortForm", () => {
+  it("plain short form with no pinpoint", () => {
+    expect(formatShortForm({ title: "Mabo", mode: "short" })).toBe("Mabo");
+  });
+
+  it("plain short form with paragraph pinpoint", () => {
+    expect(
+      formatShortForm({ title: "Mabo", mode: "short", pinpoint: { type: "para", n: 20 } }),
+    ).toBe("Mabo [20]");
+  });
+
+  it("Ibid with no pinpoint", () => {
+    expect(formatShortForm({ title: "Mabo", mode: "ibid" })).toBe("Ibid");
+  });
+
+  it("Ibid with paragraph pinpoint", () => {
+    expect(
+      formatShortForm({ title: "Mabo", mode: "ibid", pinpoint: { type: "para", n: 20 } }),
+    ).toBe("Ibid [20]");
+  });
+
+  it("subsequent reference with footnote number", () => {
+    expect(formatShortForm({ title: "Mabo", mode: "subsequent", footnoteRef: 3 })).toBe(
+      "Mabo (n 3)",
+    );
+  });
+
+  it("subsequent reference with footnote number and pinpoint", () => {
+    expect(
+      formatShortForm({
+        title: "Mabo",
+        mode: "subsequent",
+        footnoteRef: 3,
+        pinpoint: { type: "para", n: 20 },
+      }),
+    ).toBe("Mabo (n 3) [20]");
+  });
+
+  it("subsequent reference without footnoteRef", () => {
+    expect(formatShortForm({ title: "Mabo", mode: "subsequent" })).toBe("Mabo");
+  });
+});
+
+describe("parseCitation – extended pinpoint shapes", () => {
+  it("parses paragraph range pinpoint", () => {
+    const result = parseCitation("Mabo [1992] HCA 23 at [64] to [66]");
+    expect(result?.pinpoint).toBe("[64] to [66]");
+  });
+
+  it("parses page pinpoint", () => {
+    const result = parseCitation("Bowrey (1992) 175 CLR 1 at 401");
+    expect(result?.pinpoint).toBe("401");
+  });
+
+  it("parses page range pinpoint", () => {
+    const result = parseCitation("Bowrey (1992) 175 CLR 1 at 401 to 407");
+    expect(result?.pinpoint).toBe("401 to 407");
+  });
+
+  it("parses legislation pinpoint with section reference", () => {
+    const result = parseCitation("[2022] HCA 5 at s 5(2)(a)");
+    expect(result?.pinpoint).toBe("s 5(2)(a)");
+  });
+});
+
+describe("parseCitation – mixed-case reporter fix", () => {
+  it("parses FamLR reporter (mixed case)", () => {
+    const result = parseCitation("(2010) 19 FamLR 1");
+    expect(result?.reportedCitations[0]).toBe("(2010) 19 FamLR 1");
+  });
+
+  it("parses QdR reporter (mixed case)", () => {
+    const result = parseCitation("[1992] 1 QdR 1");
+    expect(result?.reportedCitations[0]).toBe("[1992] 1 QdR 1");
+  });
+});
+
+describe("isValidReportedCitation – mixed-case reporters", () => {
+  it("accepts FamLR", () => {
+    expect(isValidReportedCitation("(2010) 19 FamLR 1")).toBe(true);
+  });
+
+  it("accepts QdR", () => {
+    expect(isValidReportedCitation("[1992] 1 QdR 1")).toBe(true);
+  });
+
+  it("rejects unknown mixed-case abbreviation", () => {
+    expect(isValidReportedCitation("(2010) 19 FooBar 1")).toBe(false);
   });
 });

--- a/src/test/unit/source-store.test.ts
+++ b/src/test/unit/source-store.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFs = vi.hoisted(() => ({
+  mkdir: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  promises: mockFs,
+}));
+
+vi.mock("axios");
+vi.mock("../../services/fetcher.js");
+vi.mock("../../utils/url-guard.js");
+
+import axios from "axios";
+import { fetchDocumentText } from "../../services/fetcher.js";
+import { assertFetchableUrl } from "../../utils/url-guard.js";
+import { checkSourceFreshness, storeSource } from "../../services/source-store.js";
+
+const SOURCES_DIR = "/test/project/sources";
+const TEST_URL = "https://www.austlii.edu.au/cgi-bin/viewdoc/au/cases/cth/HCA/1992/23.html";
+const SAMPLE_TEXT = "The High Court held that native title exists.";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFs.mkdir.mockResolvedValue(undefined);
+  mockFs.writeFile.mockResolvedValue(undefined);
+  vi.mocked(assertFetchableUrl).mockReturnValue(undefined);
+});
+
+describe("checkSourceFreshness", () => {
+  it("returns fresh:true when server responds 304", async () => {
+    vi.mocked(axios.head).mockResolvedValueOnce({
+      status: 304,
+      headers: { etag: '"new-etag"', "last-modified": "Wed, 01 Jan 2026 00:00:00 GMT" },
+    });
+
+    const result = await checkSourceFreshness(
+      TEST_URL,
+      '"old-etag"',
+      "Tue, 31 Dec 2025 00:00:00 GMT",
+    );
+    expect(result.fresh).toBe(true);
+    expect(result.etag).toBe('"new-etag"');
+  });
+
+  it("returns fresh:false when server responds 200", async () => {
+    vi.mocked(axios.head).mockResolvedValueOnce({
+      status: 200,
+      headers: { etag: '"new-etag"' },
+    });
+
+    const result = await checkSourceFreshness(TEST_URL, '"old-etag"');
+    expect(result.fresh).toBe(false);
+  });
+
+  it("sends If-None-Match header when etag provided", async () => {
+    vi.mocked(axios.head).mockResolvedValueOnce({ status: 304, headers: {} });
+
+    await checkSourceFreshness(TEST_URL, '"test-etag"');
+    const callArgs = vi.mocked(axios.head).mock.calls[0]!;
+    expect(callArgs?.[1]?.headers?.["If-None-Match"]).toBe('"test-etag"');
+  });
+
+  it("sends If-Modified-Since header when lastModified provided", async () => {
+    vi.mocked(axios.head).mockResolvedValueOnce({ status: 304, headers: {} });
+
+    await checkSourceFreshness(TEST_URL, undefined, "Tue, 31 Dec 2025 00:00:00 GMT");
+    const callArgs = vi.mocked(axios.head).mock.calls[0]!;
+    expect(callArgs?.[1]?.headers?.["If-Modified-Since"]).toBe("Tue, 31 Dec 2025 00:00:00 GMT");
+  });
+
+  it("returns fresh:false on network error", async () => {
+    vi.mocked(axios.head).mockRejectedValueOnce(new Error("Network error"));
+    const result = await checkSourceFreshness(TEST_URL, '"etag"');
+    expect(result.fresh).toBe(false);
+  });
+
+  it("returns fresh:false when no conditional headers provided", async () => {
+    vi.mocked(axios.head).mockResolvedValueOnce({ status: 200, headers: {} });
+    const result = await checkSourceFreshness(TEST_URL);
+    expect(result.fresh).toBe(false);
+  });
+});
+
+describe("storeSource", () => {
+  beforeEach(() => {
+    vi.mocked(fetchDocumentText).mockResolvedValue({
+      text: SAMPLE_TEXT,
+      contentType: "text/html",
+      sourceUrl: TEST_URL,
+      ocrUsed: false,
+    });
+    // HEAD for ETag capture after fetch
+    vi.mocked(axios.head).mockResolvedValue({
+      status: 200,
+      headers: { etag: '"etag-1"', "last-modified": "Wed, 01 Jan 2026 00:00:00 GMT" },
+    });
+  });
+
+  it("downloads and writes file when no cached entry", async () => {
+    const result = await storeSource("mabo1992", TEST_URL, null, SOURCES_DIR);
+    expect(result.changed).toBe(true);
+    expect(mockFs.writeFile).toHaveBeenCalledOnce();
+    const writtenContent = mockFs.writeFile.mock.calls[0]![1] as string;
+    expect(writtenContent).toContain(`> Source: ${TEST_URL}`);
+    expect(writtenContent).toContain(SAMPLE_TEXT);
+  });
+
+  it("returns correct contentHash", async () => {
+    const result = await storeSource("mabo1992", TEST_URL, null, SOURCES_DIR);
+    expect(result.contentHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("sets changed:false when content hash matches cached hash", async () => {
+    const { createHash } = await import("node:crypto");
+    const hash = createHash("sha256").update(SAMPLE_TEXT, "utf-8").digest("hex");
+
+    const result = await storeSource("mabo1992", TEST_URL, { contentHash: hash }, SOURCES_DIR);
+    expect(result.changed).toBe(false);
+    // File should not be written again when content is unchanged
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("sets changed:true when content hash differs", async () => {
+    const result = await storeSource("mabo1992", TEST_URL, { contentHash: "oldhash" }, SOURCES_DIR);
+    expect(result.changed).toBe(true);
+    expect(mockFs.writeFile).toHaveBeenCalledOnce();
+  });
+
+  it("skips download when 304 freshness check passes", async () => {
+    // Reset HEAD mock so first call returns 304
+    vi.mocked(axios.head).mockResolvedValueOnce({ status: 304, headers: { etag: '"etag-1"' } });
+
+    const result = await storeSource(
+      "mabo1992",
+      TEST_URL,
+      { contentHash: "knowngoodhash", sourceEtag: '"etag-1"' },
+      SOURCES_DIR,
+    );
+
+    expect(result.changed).toBe(false);
+    expect(result.contentHash).toBe("knowngoodhash");
+    expect(fetchDocumentText).not.toHaveBeenCalled();
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("re-downloads when 304 check fails (stale)", async () => {
+    // HEAD returns 200 (stale)
+    vi.mocked(axios.head)
+      .mockResolvedValueOnce({ status: 200, headers: { etag: '"etag-new"' } })
+      .mockResolvedValueOnce({ status: 200, headers: { etag: '"etag-new"' } });
+
+    const result = await storeSource(
+      "mabo1992",
+      TEST_URL,
+      { contentHash: "oldhash", sourceEtag: '"etag-old"' },
+      SOURCES_DIR,
+    );
+
+    expect(fetchDocumentText).toHaveBeenCalledOnce();
+    expect(result.changed).toBe(true);
+  });
+
+  it("returns path under sourcesDir", async () => {
+    const result = await storeSource("mabo1992", TEST_URL, null, SOURCES_DIR);
+    expect(result.path).toBe(`${SOURCES_DIR}/mabo1992.md`);
+  });
+
+  it("captures etag from HEAD response", async () => {
+    const result = await storeSource("mabo1992", TEST_URL, null, SOURCES_DIR);
+    expect(result.etag).toBe('"etag-1"');
+  });
+});

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -2,6 +2,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 import type { FetchResponse } from "../services/fetcher.js";
 import type { SearchResult } from "../services/austlii.js";
+import { formatAGLC4 } from "../services/citation.js";
 
 export type ResponseFormat = "json" | "text" | "markdown" | "html";
 
@@ -23,21 +24,34 @@ function ensureContent(text: string): CallToolResult["content"] {
  * @param format - Desired output format (json, text, markdown, or html)
  * @returns An MCP {@link CallToolResult} containing the formatted content
  */
+/** Attach a canonical AGLC4 string to each search result. */
+function withAglc4(results: SearchResult[]): (SearchResult & { aglc4: string })[] {
+  return results.map((r) => ({
+    ...r,
+    aglc4: formatAGLC4({
+      title: r.title,
+      neutralCitation: r.neutralCitation,
+      reportedCitation: r.reportedCitation,
+    }),
+  }));
+}
+
 export function formatSearchResults(
   results: SearchResult[],
   format: ResponseFormat,
 ): CallToolResult {
+  const enriched = withAglc4(results);
   switch (format) {
     case "json":
       return {
-        content: ensureContent(JSON.stringify(results, null, 2)),
+        content: ensureContent(JSON.stringify(enriched, null, 2)),
         structuredContent: {
           format: "json",
-          data: results,
+          data: enriched,
         },
       };
     case "html": {
-      const rows = results
+      const rows = enriched
         .map((result) => {
           const citation = result.citation ?? result.neutralCitation ?? "";
           const reported =
@@ -45,9 +59,12 @@ export function formatSearchResults(
               ? ` <span class="reported-citation">${escapeHtml(result.reportedCitation)}</span>`
               : "";
           const summary = result.summary ? `<p>${escapeHtml(result.summary)}</p>` : "";
+          const aglc4 = result.aglc4
+            ? ` <span class="aglc4">${escapeHtml(result.aglc4)}</span>`
+            : "";
           return `<li><a href="${escapeHtml(result.url)}">${escapeHtml(result.title)}</a>${
             citation ? ` (${escapeHtml(citation)})` : ""
-          }${reported}${summary}</li>`;
+          }${reported}${aglc4}${summary}</li>`;
         })
         .join("\n");
       return {
@@ -55,14 +72,9 @@ export function formatSearchResults(
       };
     }
     case "markdown": {
-      const lines = results.map((result) => {
-        const citation = result.citation ?? result.neutralCitation ?? "";
-        const reported =
-          result.reportedCitation && result.reportedCitation !== citation
-            ? ` ${result.reportedCitation}`
-            : "";
+      const lines = enriched.map((result) => {
         const summary = result.summary ? ` - ${result.summary}` : "";
-        return `- [${result.title}](${result.url})${citation ? ` (${citation})` : ""}${reported}${summary}`;
+        return `- [${result.title}](${result.url}) (\`${result.aglc4}\`)${summary}`;
       });
       return {
         content: ensureContent(lines.join("\n")),
@@ -70,14 +82,9 @@ export function formatSearchResults(
     }
     case "text":
     default: {
-      const lines = results.map((result, idx) => {
-        const citation = result.citation ?? result.neutralCitation ?? "";
-        const reported =
-          result.reportedCitation && result.reportedCitation !== citation
-            ? ` ${result.reportedCitation}`
-            : "";
+      const lines = enriched.map((result, idx) => {
         const summary = result.summary ? `\n  ${result.summary}` : "";
-        return `${idx + 1}. ${result.title}${citation ? ` (${citation})` : ""}${reported}\n   ${result.url}${summary}`;
+        return `${idx + 1}. ${result.aglc4}\n   ${result.url}${summary}`;
       });
       return {
         content: ensureContent(lines.join("\n")),


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **AGLC4 pinpoint widening**: New `Pinpoint` union type covers all 5 AGLC4 shapes — paragraph `[N]`, page `N`, paragraph range `[N] to [N]`, page range `N to N`, and legislation `s 5(2)(a)` — with `formatPinpointRef` and `formatShortForm` (handles Ibid and subsequent `title (n X)` references)
- **Reporter pattern fix**: `REPORTED_CITATION_PATTERNS` now accepts mixed-case abbreviations (FamLR, QdR) that the REPORTERS table already defines but the regex previously rejected
- **Derived `aglc4` field on search results**: All output formats (JSON, text, markdown, HTML) now include a canonical AGLC4 string computed by the server — agents no longer hand-roll citations
- **Local citation cache** (`src/services/citation-cache.ts`): JSON store at `<AUSLAW_CACHE_DIR>/.auslaw/citations.json` with biblatex export (`@jurisdiction`/`@misc`), biblatex-compatible cite-key generation, multi-document tracking, and an embedding slot (`embedding`, `embeddingModel`) reserved for future kannon-2 / local-model integration — no schema migration needed when that ships
- **Source store** (`src/services/source-store.ts`): Auto-downloads source markdown to `sources/<citeKey>.md` on fetch; uses HTTP ETag/Last-Modified conditional GET to prefer the primary source when newer, skip re-download on 304
- **Config**: `AUSLAW_CACHE_DIR`, `AUSLAW_PROJECT_NAME`, `AUSLAW_SOURCES_DIR`, `AUSLAW_FETCH_SOURCES` env vars
- **6 new MCP tools**: `cache_citation`, `get_cached_citation`, `list_bibliography`, `export_bibliography`, `format_short_citation`, `check_source_freshness`
- `fetch_document_text` gains an optional `citeKey` parameter — when provided, auto-saves the source and updates cache freshness fields

## Test plan

- [ ] `npm run build` — TypeScript compiles cleanly
- [ ] `npx vitest run src/test/unit/` — 300 tests pass, 1 skipped (pre-existing live network test)
- [ ] `npm run lint` — 0 errors (8 pre-existing warnings in unrelated citator test)
- [ ] Smoke test `cache_citation` → verify `.auslaw/citations.json` created with correct citeKey
- [ ] Smoke test `get_cached_citation` with returned citeKey → round-trips without network call
- [ ] Smoke test `export_bibliography` → valid `.bib` file with `@jurisdiction` entries
- [ ] Smoke test `format_short_citation` with `mode: "ibid"` → returns `"Ibid"`
- [ ] Smoke test `check_source_freshness` on a cached entry with no prior source → downloads and updates cache

https://claude.ai/code/session_01Q6KyQJcwEDwDQq7SrX7Cna
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6KyQJcwEDwDQq7SrX7Cna)_

<!-- greptile_comment -->

[Greptile](https://greptile.com)
---

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a local citation cache (`citation-cache.ts`) and source store (`source-store.ts`), six new MCP tools (`cache_citation`, `get_cached_citation`, `list_bibliography`, `export_bibliography`, `format_short_citation`, `check_source_freshness`), a widened `Pinpoint` union type covering all five AGLC4 pinpoint shapes, a mixed-case reporter regex fix, and a derived `aglc4` field on all search result formats. The implementation is thorough and well-tested across 300+ unit tests.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 style/quality suggestions with no correctness or data-integrity impact.

No P0 or P1 findings. The three P2 issues (extra HEAD on unchanged content, entry-count approximation in export, stale AGENTS.md/CLAUDE.md docs) are minor and do not affect production correctness. The core citation-cache and source-store logic is correct, the new pinpoint types are well-tested, and the reporter fix is accurately scoped.

AGENTS.md and CLAUDE.md should be updated to reflect the new service files and tool count (15 tools, not 9/10).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/services/citation-cache.ts | New JSON citation cache with biblatex export, cite-key generation, upsert/lookup API, and embedding slot for future vector integration — well-structured with documented concurrency limitation for stdio transport. |
| src/services/source-store.ts | New source store for conditional-GET markdown persistence; logic is correct but issues a redundant extra HEAD request when content hash matches during a full download cycle. |
| src/services/citation.ts | Adds `Pinpoint` union type, `formatPinpointRef`, `formatShortForm`, extended multi-pattern pinpoint parsing, and mixed-case reporter fix — all well-tested with targeted new test cases. |
| src/index.ts | Adds 6 new MCP tools and extends `fetch_document_text`; entry count in `export_bibliography` uses `\n\n` split instead of array length, which could be off if field values contain blank lines. |
| src/utils/formatter.ts | Attaches computed AGLC4 string to all search result formats; markdown/text formats simplified to use AGLC4 string directly, dropping legacy `citation` fallback (which is always `undefined` in practice). |
| src/constants.ts | Reporter regex widened to `[A-Za-z]{2,8}` for mixed-case support; cache version constant and directory name constant added. |
| src/config.ts | Adds `cache` and `sources` config sections with sensible defaults derived from `AUSLAW_CACHE_DIR`, `AUSLAW_PROJECT_NAME`, `AUSLAW_SOURCES_DIR`, and `AUSLAW_FETCH_SOURCES`. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant MCP as MCP Server (index.ts)
    participant Cache as citation-cache.ts
    participant Store as source-store.ts
    participant FS as File System
    participant Net as Network (AustLII/jade.io)

    Note over Agent,Net: cache_citation flow
    Agent->>MCP: cache_citation(title, url, neutralCitation, ...)
    MCP->>MCP: formatAGLC4(title, neutralCitation, reportedCitation)
    MCP->>Cache: upsertCitation(cacheDir, input)
    Cache->>FS: loadCache (.auslaw/citations.json)
    Cache->>Cache: generateCiteKey / find existing
    Cache->>FS: saveCache (.auslaw/citations.json)
    Cache-->>MCP: citeKey
    MCP-->>Agent: { citeKey, aglc4Full }

    Note over Agent,Net: fetch_document_text + citeKey flow
    Agent->>MCP: fetch_document_text(url, citeKey)
    MCP->>Net: fetchDocumentText(url)
    Net-->>MCP: { text, ... }
    MCP->>Cache: getCitation(cacheDir, citeKey)
    Cache->>FS: loadCache
    Cache-->>MCP: existing entry (ETag, hash)
    MCP->>Store: storeSource(citeKey, url, existing, sourcesDir)
    Store->>Net: HEAD url (conditional, If-None-Match / If-Modified-Since)
    alt 304 Not Modified
        Net-->>Store: 304
        Store-->>MCP: { changed: false, contentHash }
    else 200 / no ETag
        Net-->>Store: 200
        Store->>Net: fetchDocumentText(url)
        Net-->>Store: full text
        Store->>FS: write sources/citeKey.md
        Store-->>MCP: { changed: true, contentHash, etag }
    end
    MCP->>Cache: updateSourceFields(citeKey, { sourceFile, contentHash, etag })
    Cache->>FS: saveCache
    MCP-->>Agent: formatted document text

    Note over Agent,Net: check_source_freshness flow
    Agent->>MCP: check_source_freshness(citeKey)
    MCP->>Cache: getCitation(cacheDir, citeKey)
    Cache-->>MCP: entry (url, sourceEtag, contentHash)
    MCP->>Store: checkSourceFreshness(url, etag, lastModified)
    Store->>Net: HEAD url
    alt fresh (304)
        Net-->>Store: 304
        Store-->>MCP: { fresh: true }
        MCP-->>Agent: { fresh: true, sourceFile }
    else stale (200)
        Net-->>Store: 200
        Store-->>MCP: { fresh: false }
        MCP->>Store: storeSource(citeKey, url, entry, sourcesDir)
        Store->>FS: write updated source
        MCP->>Cache: updateSourceFields(...)
        MCP-->>Agent: { fresh: false, changed: true }
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (5)</h3></summary>

1. `src/index.ts`, line 134-136 ([link](https://github.com/russellbrenner/auslaw-mcp/blob/f5af491d6a8e22b6f93e5af24deea5a5d710e9d0/src/index.ts#L134-L136)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Misleading tool description — `citeKey` required for auto-save**

   The registered tool description states "When AUSLAW_FETCH_SOURCES is not set to 'false', saves a local markdown copy …" but the actual guard is `config.sources.fetchByDefault && citeKey`. Without an explicit `citeKey`, no source is ever saved regardless of the env var. Agents calling this tool will incorrectly believe every fetch triggers a save; the description should mention that `citeKey` must be supplied for the auto-save behaviour to activate.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/index.ts
   Line: 134-136

   Comment:
   **Misleading tool description — `citeKey` required for auto-save**

   The registered tool description states "When AUSLAW_FETCH_SOURCES is not set to 'false', saves a local markdown copy …" but the actual guard is `config.sources.fetchByDefault && citeKey`. Without an explicit `citeKey`, no source is ever saved regardless of the env var. Agents calling this tool will incorrectly believe every fetch triggers a save; the description should mention that `citeKey` must be supplied for the auto-save behaviour to activate.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Findex.ts%0ALine%3A%20134-136%0A%0AComment%3A%0A**Misleading%20tool%20description%20%E2%80%94%20%60citeKey%60%20required%20for%20auto-save**%0A%0AThe%20registered%20tool%20description%20states%20%22When%20AUSLAW_FETCH_SOURCES%20is%20not%20set%20to%20'false'%2C%20saves%20a%20local%20markdown%20copy%20%E2%80%A6%22%20but%20the%20actual%20guard%20is%20%60config.sources.fetchByDefault%20%26%26%20citeKey%60.%20Without%20an%20explicit%20%60citeKey%60%2C%20no%20source%20is%20ever%20saved%20regardless%20of%20the%20env%20var.%20Agents%20calling%20this%20tool%20will%20incorrectly%20believe%20every%20fetch%20triggers%20a%20save%3B%20the%20description%20should%20mention%20that%20%60citeKey%60%20must%20be%20supplied%20for%20the%20auto-save%20behaviour%20to%20activate.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=russellbrenner%2Fauslaw-mcp&pr=79&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>

2. `src/index.ts`, line 364 ([link](https://github.com/russellbrenner/auslaw-mcp/blob/f5af491d6a8e22b6f93e5af24deea5a5d710e9d0/src/index.ts#L364)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Magic string — use `AUSLAW_CACHE_DIR_NAME` constant**

   `".auslaw"` is hardcoded here, but the constant `AUSLAW_CACHE_DIR_NAME` (defined in `src/constants.ts` and used by `getCachePath` in the cache service) already carries this value. If the directory name is ever changed, this path will silently diverge from where the cache actually lives. Per the project's "no magic strings" convention, use the constant:

   ```typescript
   const defaultPath = path.join(config.cache.dir, AUSLAW_CACHE_DIR_NAME, `${config.cache.projectName}.bib`);
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/index.ts
   Line: 364

   Comment:
   **Magic string — use `AUSLAW_CACHE_DIR_NAME` constant**

   `".auslaw"` is hardcoded here, but the constant `AUSLAW_CACHE_DIR_NAME` (defined in `src/constants.ts` and used by `getCachePath` in the cache service) already carries this value. If the directory name is ever changed, this path will silently diverge from where the cache actually lives. Per the project's "no magic strings" convention, use the constant:

   ```typescript
   const defaultPath = path.join(config.cache.dir, AUSLAW_CACHE_DIR_NAME, `${config.cache.projectName}.bib`);
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Findex.ts%0ALine%3A%20364%0A%0AComment%3A%0A**Magic%20string%20%E2%80%94%20use%20%60AUSLAW_CACHE_DIR_NAME%60%20constant**%0A%0A%60%22.auslaw%22%60%20is%20hardcoded%20here%2C%20but%20the%20constant%20%60AUSLAW_CACHE_DIR_NAME%60%20%28defined%20in%20%60src%2Fconstants.ts%60%20and%20used%20by%20%60getCachePath%60%20in%20the%20cache%20service%29%20already%20carries%20this%20value.%20If%20the%20directory%20name%20is%20ever%20changed%2C%20this%20path%20will%20silently%20diverge%20from%20where%20the%20cache%20actually%20lives.%20Per%20the%20project's%20%22no%20magic%20strings%22%20convention%2C%20use%20the%20constant%3A%0A%0A%60%60%60typescript%0Aconst%20defaultPath%20%3D%20path.join%28config.cache.dir%2C%20AUSLAW_CACHE_DIR_NAME%2C%20%60%24%7Bconfig.cache.projectName%7D.bib%60%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=russellbrenner%2Fauslaw-mcp&pr=79&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>

3. `src/index.ts`, line 367-389 ([link](https://github.com/russellbrenner/auslaw-mcp/blob/f5af491d6a8e22b6f93e5af24deea5a5d710e9d0/src/index.ts#L367-L389)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`export_bibliography` returns `path` even when no file is written**

   When the cache is empty, `bibText` is `""` (falsy), the `if (bibText)` block is skipped, and no `.bib` file is created — but the response still includes `"path": writePath`. A caller (or agent) that reads `path` from the response and tries to open the file will find it missing. Consider returning a clear signal when nothing was exported:

   ```typescript
   if (!bibText) {
     return {
       content: [{ type: "text" as const, text: JSON.stringify({ path: null, entries: 0, bib: "" }, null, 2) }],
     };
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/index.ts
   Line: 367-389

   Comment:
   **`export_bibliography` returns `path` even when no file is written**

   When the cache is empty, `bibText` is `""` (falsy), the `if (bibText)` block is skipped, and no `.bib` file is created — but the response still includes `"path": writePath`. A caller (or agent) that reads `path` from the response and tries to open the file will find it missing. Consider returning a clear signal when nothing was exported:

   ```typescript
   if (!bibText) {
     return {
       content: [{ type: "text" as const, text: JSON.stringify({ path: null, entries: 0, bib: "" }, null, 2) }],
     };
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Findex.ts%0ALine%3A%20367-389%0A%0AComment%3A%0A**%60export_bibliography%60%20returns%20%60path%60%20even%20when%20no%20file%20is%20written**%0A%0AWhen%20the%20cache%20is%20empty%2C%20%60bibText%60%20is%20%60%22%22%60%20%28falsy%29%2C%20the%20%60if%20%28bibText%29%60%20block%20is%20skipped%2C%20and%20no%20%60.bib%60%20file%20is%20created%20%E2%80%94%20but%20the%20response%20still%20includes%20%60%22path%22%3A%20writePath%60.%20A%20caller%20%28or%20agent%29%20that%20reads%20%60path%60%20from%20the%20response%20and%20tries%20to%20open%20the%20file%20will%20find%20it%20missing.%20Consider%20returning%20a%20clear%20signal%20when%20nothing%20was%20exported%3A%0A%0A%60%60%60typescript%0Aif%20%28!bibText%29%20%7B%0A%20%20return%20%7B%0A%20%20%20%20content%3A%20%5B%7B%20type%3A%20%22text%22%20as%20const%2C%20text%3A%20JSON.stringify%28%7B%20path%3A%20null%2C%20entries%3A%200%2C%20bib%3A%20%22%22%20%7D%2C%20null%2C%202%29%20%7D%5D%2C%0A%20%20%7D%3B%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=russellbrenner%2Fauslaw-mcp&pr=79&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>

4. `src/services/citation-cache.ts`, line 773-834 ([link](https://github.com/russellbrenner/auslaw-mcp/blob/f5af491d6a8e22b6f93e5af24deea5a5d710e9d0/src/services/citation-cache.ts#L773-L834)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Concurrent writes may silently lose data**

   `upsertCitation` and `updateSourceFields` both follow a load → mutate → save pattern with no file locking. If two MCP tool calls run concurrently (e.g., `cache_citation` and `fetch_document_text` with `citeKey`) they will each read the same on-disk state, apply their mutations independently, and the last writer will overwrite the first writer's changes. For an MCP server handling sequential single-client sessions this is unlikely to bite, but it is worth at minimum a comment flagging the limitation, and in a multi-client or streamed-HTTP scenario it can cause silent data loss.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/services/citation-cache.ts
   Line: 773-834

   Comment:
   **Concurrent writes may silently lose data**

   `upsertCitation` and `updateSourceFields` both follow a load → mutate → save pattern with no file locking. If two MCP tool calls run concurrently (e.g., `cache_citation` and `fetch_document_text` with `citeKey`) they will each read the same on-disk state, apply their mutations independently, and the last writer will overwrite the first writer's changes. For an MCP server handling sequential single-client sessions this is unlikely to bite, but it is worth at minimum a comment flagging the limitation, and in a multi-client or streamed-HTTP scenario it can cause silent data loss.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fservices%2Fcitation-cache.ts%0ALine%3A%20773-834%0A%0AComment%3A%0A**Concurrent%20writes%20may%20silently%20lose%20data**%0A%0A%60upsertCitation%60%20and%20%60updateSourceFields%60%20both%20follow%20a%20load%20%E2%86%92%20mutate%20%E2%86%92%20save%20pattern%20with%20no%20file%20locking.%20If%20two%20MCP%20tool%20calls%20run%20concurrently%20%28e.g.%2C%20%60cache_citation%60%20and%20%60fetch_document_text%60%20with%20%60citeKey%60%29%20they%20will%20each%20read%20the%20same%20on-disk%20state%2C%20apply%20their%20mutations%20independently%2C%20and%20the%20last%20writer%20will%20overwrite%20the%20first%20writer's%20changes.%20For%20an%20MCP%20server%20handling%20sequential%20single-client%20sessions%20this%20is%20unlikely%20to%20bite%2C%20but%20it%20is%20worth%20at%20minimum%20a%20comment%20flagging%20the%20limitation%2C%20and%20in%20a%20multi-client%20or%20streamed-HTTP%20scenario%20it%20can%20cause%20silent%20data%20loss.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=russellbrenner%2Fauslaw-mcp&pr=79&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>

5. `src/services/citation-cache.ts`, line 687-701 ([link](https://github.com/russellbrenner/auslaw-mcp/blob/f5af491d6a8e22b6f93e5af24deea5a5d710e9d0/src/services/citation-cache.ts#L687-L701)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`version` field is stored but never checked**

   `AUSLAW_CACHE_VERSION` is written into every new cache file and will be incremented on breaking schema changes, but `loadCache` never inspects it. A cache written with a future schema version will be silently loaded and likely misinterpreted. At minimum, a warning log (or throw) when `cache.version > AUSLAW_CACHE_VERSION` would prevent confusing downstream failures:

   ```typescript
   if (parsed.version !== undefined && parsed.version > AUSLAW_CACHE_VERSION) {
     // Warn — caller may be running against a newer cache schema
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/services/citation-cache.ts
   Line: 687-701

   Comment:
   **`version` field is stored but never checked**

   `AUSLAW_CACHE_VERSION` is written into every new cache file and will be incremented on breaking schema changes, but `loadCache` never inspects it. A cache written with a future schema version will be silently loaded and likely misinterpreted. At minimum, a warning log (or throw) when `cache.version > AUSLAW_CACHE_VERSION` would prevent confusing downstream failures:

   ```typescript
   if (parsed.version !== undefined && parsed.version > AUSLAW_CACHE_VERSION) {
     // Warn — caller may be running against a newer cache schema
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fservices%2Fcitation-cache.ts%0ALine%3A%20687-701%0A%0AComment%3A%0A**%60version%60%20field%20is%20stored%20but%20never%20checked**%0A%0A%60AUSLAW_CACHE_VERSION%60%20is%20written%20into%20every%20new%20cache%20file%20and%20will%20be%20incremented%20on%20breaking%20schema%20changes%2C%20but%20%60loadCache%60%20never%20inspects%20it.%20A%20cache%20written%20with%20a%20future%20schema%20version%20will%20be%20silently%20loaded%20and%20likely%20misinterpreted.%20At%20minimum%2C%20a%20warning%20log%20%28or%20throw%29%20when%20%60cache.version%20%3E%20AUSLAW_CACHE_VERSION%60%20would%20prevent%20confusing%20downstream%20failures%3A%0A%0A%60%60%60typescript%0Aif%20%28parsed.version%20!%3D%3D%20undefined%20%26%26%20parsed.version%20%3E%20AUSLAW_CACHE_VERSION%29%20%7B%0A%20%20%2F%2F%20Warn%20%E2%80%94%20caller%20may%20be%20running%20against%20a%20newer%20cache%20schema%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=russellbrenner%2Fauslaw-mcp&pr=79&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Asrc%2Fservices%2Fcitation.ts%3A117-122%0A**Mixed-case%20reporter%20accepted%20in%20%60parseCitation%60%20but%20only%20uppercase%20fallback%20in%20%60isValidReportedCitation%60**%0A%0A%60parseCitation%60%20accepts%20mixed-case%20reporters%20via%20the%20REPORTERS%20table%20%28first%20branch%29%20and%20all-uppercase%20unknowns%20via%20the%20second%20branch.%20%60isValidReportedCitation%60%20uses%20the%20same%20logic.%20This%20is%20consistent%2C%20but%20it%20means%20that%20a%20known%20reporter%20like%20%60FamLR%60%20will%20round-trip%20correctly%20%28parsed%2C%20then%20validates%29%2C%20while%20an%20unknown%20mixed-case%20abbreviation%20%28e.g.%20%60FooBar%60%29%20parses%20successfully%20in%20%60parseCitation%60%20but%20fails%20in%20%60isValidReportedCitation%60.%20The%20test%20suite%20covers%20this%20correctly%2C%20but%20it%20is%20worth%20confirming%20the%20asymmetry%20is%20intentional%3A%20%60parseCitation%60%20silently%20accepts%20any%20known-table%20reporter%20regardless%20of%20case%2C%20whereas%20%60isValidReportedCitation%60%20rejects%20unknown%20mixed-case%20reporters.%0A%0A%23%23%23%20Issue%202%20of%204%0Asrc%2Fservices%2Fsource-store.ts%3A108-121%0A**Extra%20HEAD%20request%20issued%20even%20when%20content%20hash%20matches**%0A%0AWhen%20%60changed%60%20is%20%60false%60%20%28the%20hash%20matches%20the%20cached%20value%29%2C%20the%20function%20still%20issues%20a%20trailing%20%60axios.head%60%20to%20capture%20ETag%2FLast-Modified%20for%20the%20next%20freshness%20check.%20This%20means%20a%20full%20content%20download%20_plus_%20an%20extra%20HEAD%20request%20is%20made%2C%20even%20when%20the%20document%20has%20not%20changed.%20Consider%20skipping%20the%20HEAD%20when%20the%20hash%20comparison%20shows%20no%20change%20and%20no%20ETag%2FLast-Modified%20was%20returned%20by%20the%20earlier%20%60fetchDocumentText%60%20call.%0A%0A%23%23%23%20Issue%203%20of%204%0Asrc%2Findex.ts%3A648-649%0A**%60export_bibliography%60%20entry%20count%20may%20be%20incorrect%20when%20field%20values%20contain%20double%20newlines**%0A%0AThe%20response%20counts%20entries%20by%20splitting%20%60bibText%60%20on%20%60%22%5Cn%5Cn%22%60.%20Because%20%60escapeBibValue%60%20only%20escapes%20curly%20braces%20and%20not%20newlines%2C%20a%20%60note%60%2C%20%60title%60%2C%20or%20%60summary%60%20field%20containing%20a%20blank%20line%20would%20split%20the%20entry%20mid-way%20and%20inflate%20the%20count.%20Using%20%60entries.length%60%20from%20%60listCitations%60%20would%20be%20exact%3A%0A%0A%60%60%60typescript%0Aentries%3A%20%28await%20listCitations%28config.cache.dir%2C%20document%29%29.length%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0AAGENTS.md%3A15-30%0A**Architecture%20section%20and%20tool%20count%20not%20updated**%0A%0A%60AGENTS.md%60%20lists%209%20tools%20and%20does%20not%20include%20the%20two%20new%20service%20files%20added%20in%20this%20PR%3A%0A%0A%60%60%60%0Asrc%2Fservices%2Fcitation-cache.ts%20%20%20%23%20local%20JSON%20citation%20cache%2C%20biblatex%20export%0Asrc%2Fservices%2Fsource-store.ts%20%20%20%20%20%23%20conditional-GET%20source%20markdown%20store%0A%60%60%60%0A%0AThe%20new%20tool%20count%20is%2015%20%289%20prior%20%2B%206%20new%29.%20%60CLAUDE.md%60%20similarly%20refers%20to%20%2210%20tool%20registrations%22.%20Both%20files%20should%20be%20updated%20so%20AI%20agents%20working%20on%20future%20PRs%20have%20an%20accurate%20picture%20of%20the%20architecture.%0A%0A&repo=russellbrenner%2Fauslaw-mcp&pr=79&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
src/services/citation.ts:117-122
**Mixed-case reporter accepted in `parseCitation` but only uppercase fallback in `isValidReportedCitation`**

`parseCitation` accepts mixed-case reporters via the REPORTERS table (first branch) and all-uppercase unknowns via the second branch. `isValidReportedCitation` uses the same logic. This is consistent, but it means that a known reporter like `FamLR` will round-trip correctly (parsed, then validates), while an unknown mixed-case abbreviation (e.g. `FooBar`) parses successfully in `parseCitation` but fails in `isValidReportedCitation`. The test suite covers this correctly, but it is worth confirming the asymmetry is intentional: `parseCitation` silently accepts any known-table reporter regardless of case, whereas `isValidReportedCitation` rejects unknown mixed-case reporters.

### Issue 2 of 4
src/services/source-store.ts:108-121
**Extra HEAD request issued even when content hash matches**

When `changed` is `false` (the hash matches the cached value), the function still issues a trailing `axios.head` to capture ETag/Last-Modified for the next freshness check. This means a full content download _plus_ an extra HEAD request is made, even when the document has not changed. Consider skipping the HEAD when the hash comparison shows no change and no ETag/Last-Modified was returned by the earlier `fetchDocumentText` call.

### Issue 3 of 4
src/index.ts:648-649
**`export_bibliography` entry count may be incorrect when field values contain double newlines**

The response counts entries by splitting `bibText` on `"\n\n"`. Because `escapeBibValue` only escapes curly braces and not newlines, a `note`, `title`, or `summary` field containing a blank line would split the entry mid-way and inflate the count. Using `entries.length` from `listCitations` would be exact:

```typescript
entries: (await listCitations(config.cache.dir, document)).length,
```

### Issue 4 of 4
AGENTS.md:15-30
**Architecture section and tool count not updated**

`AGENTS.md` lists 9 tools and does not include the two new service files added in this PR:

```
src/services/citation-cache.ts   # local JSON citation cache, biblatex export
src/services/source-store.ts     # conditional-GET source markdown store
```

The new tool count is 15 (9 prior + 6 new). `CLAUDE.md` similarly refers to "10 tool registrations". Both files should be updated so AI agents working on future PRs have an accurate picture of the architecture.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address five code review issues in ..."](https://github.com/russellbrenner/auslaw-mcp/commit/71437e2c4b9d4c8def61882a065c883c68dd70e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30463530)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=89734a09-872c-43c2-8ed7-2c9e33db6438))
- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=c8bc2bc6-9321-4ddd-b0a0-728a7fc95ddc))

<!-- /greptile_comment -->