### PR TITLE
Add cited-by cache with configurable source download

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -99,7 +99,7 @@ export function loadConfig(): Config {
     citedBy: {
       enabled: process.env.AUSLAW_CACHE_CITED_BY !== "false",
       downloadSources: process.env.AUSLAW_DOWNLOAD_CITED_BY_SOURCES !== "false",
-      downloadLimit: parseInt(process.env.AUSLAW_CITED_BY_DOWNLOAD_LIMIT ?? "5", 10),
+      downloadLimit: parseInt(process.env.AUSLAW_CITED_BY_DOWNLOAD_LIMIT ?? "5", 10) || 5,
     },
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,14 @@ export interface Config {
     /** When true, fetch_document_text automatically saves a local source copy. */
     fetchByDefault: boolean;
   };
+  citedBy: {
+    /** Cache cited-by results from jade.io citator lookups. */
+    enabled: boolean;
+    /** Download source files for the top-N citing cases when caching cited-by results. */
+    downloadSources: boolean;
+    /** Maximum number of citing-case sources to download per lookup. */
+    downloadLimit: number;
+  };
 }
 
 /**
@@ -87,6 +95,11 @@ export function loadConfig(): Config {
     sources: {
       dir: sourcesDir,
       fetchByDefault: process.env.AUSLAW_FETCH_SOURCES !== "false",
+    },
+    citedBy: {
+      enabled: process.env.AUSLAW_CACHE_CITED_BY !== "false",
+      downloadSources: process.env.AUSLAW_DOWNLOAD_CITED_BY_SOURCES !== "false",
+      downloadLimit: parseInt(process.env.AUSLAW_CITED_BY_DOWNLOAD_LIMIT ?? "5", 10),
     },
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,17 +21,25 @@ import {
   validateCitation,
   parseCitation,
   generatePinpoint,
+  normaliseCitation,
 } from "./services/citation.js";
+import {
+  NEUTRAL_CITATION_PATTERN,
+  COURT_TO_AUSTLII_PATH,
+  AUSLAW_CACHE_DIR_NAME,
+} from "./constants.js";
 import {
   upsertCitation,
   getCitation,
   listCitations,
   exportBib,
   updateSourceFields,
+  updateCitedBy,
+  updateCitedBySource,
+  type CitedByRef,
 } from "./services/citation-cache.js";
 import { storeSource, checkSourceFreshness } from "./services/source-store.js";
 import { config } from "./config.js";
-import { AUSLAW_CACHE_DIR_NAME } from "./constants.js";
 
 const formatEnum = z.enum(["json", "text", "markdown", "html"]).default("json");
 const jurisdictionEnum = z.enum([
@@ -55,6 +63,34 @@ const caseMethodEnum = z
 const legislationMethodEnum = z
   .enum(["auto", "title", "phrase", "all", "any", "near", "legis", "boolean"])
   .default("auto");
+
+/**
+ * Derive an AustLII URL from a neutral citation without a network call.
+ * Returns undefined when the court code is not in COURT_TO_AUSTLII_PATH.
+ */
+function austliiUrlFromNeutral(neutralCitation: string): string | undefined {
+  const m = normaliseCitation(neutralCitation).match(NEUTRAL_CITATION_PATTERN);
+  if (!m) return undefined;
+  const [, year, court, num] = m;
+  const austliiPath = COURT_TO_AUSTLII_PATH[court!];
+  if (!austliiPath) return undefined;
+  return `https://www.austlii.edu.au/cgi-bin/viewdoc/${austliiPath}/${year}/${num}.html`;
+}
+
+/**
+ * Build a filesystem-safe key for a cited-by source file.
+ * e.g. parent "mabo1992" + "[2024] HCA 5" → "mabo1992_citing_2024_hca_5"
+ */
+function citedBySourceKey(parentCiteKey: string, neutralCitation: string): string {
+  const slug = neutralCitation
+    .replace(/[[\]]/g, "")
+    .replace(/\s+/g, "_")
+    .replace(/[^a-zA-Z0-9_]/g, "")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "")
+    .toLowerCase();
+  return `${parentCiteKey}_citing_${slug}`;
+}
 
 /**
  * Build a fresh McpServer with all tools registered.
@@ -863,6 +899,206 @@ function createMcpServer(): McpServer {
                 lastChecked: new Date().toISOString(),
                 etag: freshness.etag ?? entry.sourceEtag,
                 lastModified: freshness.lastModified ?? entry.sourceLastModified,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+
+  // ── cache_cited_by ────────────────────────────────────────────────────────
+  const cacheCitedByShape = {
+    citeKey: z
+      .string()
+      .min(1)
+      .describe("Cite key of the parent case whose citing cases should be fetched and cached"),
+  };
+  const cacheCitedByParser = z.object(cacheCitedByShape);
+
+  server.registerTool(
+    "cache_cited_by",
+    {
+      title: "Cache Cited-By Results",
+      description:
+        "Fetch citing cases for a cached citation from jade.io and store them locally. " +
+        "Metadata is saved for all results; source files are downloaded for the top N entries " +
+        "(controlled by AUSLAW_CITED_BY_DOWNLOAD_LIMIT, default 5). " +
+        "Requires JADE_SESSION_COOKIE. Can be disabled via AUSLAW_CACHE_CITED_BY=false.",
+      inputSchema: cacheCitedByShape,
+    },
+    async (rawInput) => {
+      const { citeKey } = cacheCitedByParser.parse(rawInput);
+
+      if (!config.citedBy.enabled) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: "Cited-by caching is disabled (AUSLAW_CACHE_CITED_BY=false)",
+              }),
+            },
+          ],
+        };
+      }
+
+      const parent = await getCitation(config.cache.dir, citeKey);
+      if (!parent) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: `No cached citation found for key: ${citeKey}` }),
+            },
+          ],
+        };
+      }
+
+      // Search jade.io for cases that cite this one
+      const query = parent.neutralCitation ?? parent.title;
+      const { results, totalCount } = await searchCitingCases(query);
+
+      // Build CitedByRef entries — prefer AustLII URL where derivable
+      const refs: CitedByRef[] = results.map((r) => {
+        const derivedUrl = r.neutralCitation ? austliiUrlFromNeutral(r.neutralCitation) : undefined;
+        const year = r.neutralCitation
+          ? parseInt(r.neutralCitation.match(/\[(\d{4})\]/)?.[1] ?? "", 10) || undefined
+          : undefined;
+        return {
+          title: r.caseName,
+          neutralCitation: r.neutralCitation || undefined,
+          aglc4Full: r.neutralCitation
+            ? formatAGLC4({ title: r.caseName, neutralCitation: r.neutralCitation })
+            : r.caseName,
+          url: derivedUrl ?? r.jadeUrl,
+          year,
+          court: r.court,
+        };
+      });
+
+      await updateCitedBy(config.cache.dir, citeKey, refs, totalCount);
+
+      // Optionally download sources for the top-N refs
+      let sourcesDownloaded = 0;
+      if (config.citedBy.downloadSources) {
+        const toDownload = refs.slice(0, config.citedBy.downloadLimit);
+        for (const ref of toDownload) {
+          if (!ref.url || !ref.neutralCitation) continue;
+          try {
+            const fileKey = citedBySourceKey(citeKey, ref.neutralCitation);
+            const storeResult = await storeSource(fileKey, ref.url, null, config.sources.dir);
+            const relPath = path.relative(config.cache.dir, storeResult.path);
+            await updateCitedBySource(config.cache.dir, citeKey, ref.neutralCitation, {
+              sourceFile: relPath,
+              sourceFetchedAt: new Date().toISOString(),
+              contentHash: storeResult.contentHash,
+              sourceEtag: storeResult.etag,
+              sourceLastModified: storeResult.lastModified,
+            });
+            sourcesDownloaded++;
+          } catch {
+            // Best-effort — one failure should not abort the rest
+          }
+        }
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                citeKey,
+                totalCount,
+                cached: refs.length,
+                sourcesDownloaded,
+                citedByFetchedAt: new Date().toISOString(),
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+
+  // ── get_cited_by ──────────────────────────────────────────────────────────
+  const getCitedByShape = {
+    citeKey: z
+      .string()
+      .min(1)
+      .describe("Cite key of the case to retrieve cached cited-by data for"),
+    format: formatEnum.optional(),
+  };
+  const getCitedByParser = z.object(getCitedByShape);
+
+  server.registerTool(
+    "get_cited_by",
+    {
+      title: "Get Cached Cited-By Data",
+      description:
+        "Return the locally cached cited-by list for a citation. Zero network calls. " +
+        "Use cache_cited_by first to populate the data.",
+      inputSchema: getCitedByShape,
+    },
+    async (rawInput) => {
+      const { citeKey, format } = getCitedByParser.parse(rawInput);
+      const entry = await getCitation(config.cache.dir, citeKey);
+
+      if (!entry) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ found: false, citeKey }),
+            },
+          ],
+        };
+      }
+
+      if (!entry.citedBy || entry.citedBy.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                found: true,
+                citeKey,
+                citedByFetchedAt: entry.citedByFetchedAt ?? null,
+                totalCount: entry.citedByTotalCount ?? 0,
+                citedBy: [],
+                note: "No cited-by data cached. Run cache_cited_by to populate.",
+              }),
+            },
+          ],
+        };
+      }
+
+      const fmt = format ?? "json";
+      if (fmt === "markdown") {
+        const header = `**${entry.citedBy.length} of ${entry.citedByTotalCount ?? "?"} citing cases** (fetched ${entry.citedByFetchedAt ?? "unknown"})`;
+        const lines = entry.citedBy.map((r) => {
+          const source = r.sourceFile ? ` — source: \`${r.sourceFile}\`` : "";
+          return `- ${r.aglc4Full ?? r.title}${source}`;
+        });
+        return { content: [{ type: "text" as const, text: [header, "", ...lines].join("\n") }] };
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                found: true,
+                citeKey,
+                citedByFetchedAt: entry.citedByFetchedAt,
+                totalCount: entry.citedByTotalCount,
+                citedBy: entry.citedBy,
               },
               null,
               2,

--- a/src/index.ts
+++ b/src/index.ts
@@ -961,6 +961,14 @@ function createMcpServer(): McpServer {
       const query = parent.neutralCitation ?? parent.title;
       const { results, totalCount } = await searchCitingCases(query);
 
+      // Snapshot prior source fields so conditional GET (ETag/Last-Modified)
+      // works correctly when cache_cited_by is called a second time.
+      const priorSources = new Map(
+        (parent.citedBy ?? [])
+          .filter((r) => r.neutralCitation)
+          .map((r) => [r.neutralCitation!, r] as const),
+      );
+
       // Build CitedByRef entries — prefer AustLII URL where derivable
       const refs: CitedByRef[] = results.map((r) => {
         const derivedUrl = r.neutralCitation ? austliiUrlFromNeutral(r.neutralCitation) : undefined;
@@ -979,7 +987,8 @@ function createMcpServer(): McpServer {
         };
       });
 
-      await updateCitedBy(config.cache.dir, citeKey, refs, totalCount);
+      const now = new Date().toISOString();
+      await updateCitedBy(config.cache.dir, citeKey, refs, totalCount, now);
 
       // Optionally download sources for the top-N refs
       let sourcesDownloaded = 0;
@@ -989,11 +998,12 @@ function createMcpServer(): McpServer {
           if (!ref.url || !ref.neutralCitation) continue;
           try {
             const fileKey = citedBySourceKey(citeKey, ref.neutralCitation);
-            const storeResult = await storeSource(fileKey, ref.url, null, config.sources.dir);
+            const prior = priorSources.get(ref.neutralCitation) ?? null;
+            const storeResult = await storeSource(fileKey, ref.url, prior, config.sources.dir);
             const relPath = path.relative(config.cache.dir, storeResult.path);
             await updateCitedBySource(config.cache.dir, citeKey, ref.neutralCitation, {
               sourceFile: relPath,
-              sourceFetchedAt: new Date().toISOString(),
+              sourceFetchedAt: now,
               contentHash: storeResult.contentHash,
               sourceEtag: storeResult.etag,
               sourceLastModified: storeResult.lastModified,
@@ -1015,7 +1025,7 @@ function createMcpServer(): McpServer {
                 totalCount,
                 cached: refs.length,
                 sourcesDownloaded,
-                citedByFetchedAt: new Date().toISOString(),
+                citedByFetchedAt: now,
               },
               null,
               2,
@@ -1032,7 +1042,7 @@ function createMcpServer(): McpServer {
       .string()
       .min(1)
       .describe("Cite key of the case to retrieve cached cited-by data for"),
-    format: formatEnum.optional(),
+    format: z.enum(["json", "markdown"]).default("json").optional(),
   };
   const getCitedByParser = z.object(getCitedByShape);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -957,9 +957,41 @@ function createMcpServer(): McpServer {
         };
       }
 
+      if (!config.jade.sessionCookie) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: "JADE_SESSION_COOKIE is required to fetch cited-by data",
+              }),
+            },
+          ],
+        };
+      }
+
       // Search jade.io for cases that cite this one
       const query = parent.neutralCitation ?? parent.title;
       const { results, totalCount } = await searchCitingCases(query);
+
+      // Guard: if the API returns nothing but we have prior data, treat this as
+      // a likely failure (bad/expired cookie, network error) rather than a
+      // genuine empty set — preserving existing cache instead of erasing it.
+      if (results.length === 0 && totalCount === 0 && (parent.citedBy?.length ?? 0) > 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error:
+                  "jade.io returned no results but existing cited-by data is present. " +
+                  "The session cookie may be expired. Existing cache preserved.",
+                existingCount: parent.citedBy!.length,
+              }),
+            },
+          ],
+        };
+      }
 
       // Snapshot prior source fields so conditional GET (ETag/Last-Modified)
       // works correctly when cache_cited_by is called a second time.

--- a/src/services/citation-cache.ts
+++ b/src/services/citation-cache.ts
@@ -15,6 +15,30 @@ const CACHE_FILE_NAME = "citations.json";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+/**
+ * Metadata for a case that cites the parent entry.
+ * Source-download fields are populated for the top-N entries when
+ * AUSLAW_DOWNLOAD_CITED_BY_SOURCES is enabled.
+ */
+export interface CitedByRef {
+  /** Cite key of this citing case if it is also a main-cache entry. */
+  citeKey?: string;
+  title: string;
+  neutralCitation?: string;
+  aglc4Full?: string;
+  /** Primary URL — AustLII if derivable from neutral citation, otherwise jade.io. */
+  url?: string;
+  year?: number;
+  court?: string;
+  /** Relative path from cacheDir of the downloaded source markdown (if any). */
+  sourceFile?: string;
+  /** ISO timestamp of the most recent source download for this ref. */
+  sourceFetchedAt?: string;
+  contentHash?: string;
+  sourceEtag?: string;
+  sourceLastModified?: string;
+}
+
 export interface CachedCitation {
   /** biblatex-compatible cite key, unique within this project. */
   citeKey: string;
@@ -49,6 +73,14 @@ export interface CachedCitation {
   court?: string;
   keywords?: string[];
   summary?: string;
+
+  // Cited-by — populated by cache_cited_by / refresh_cited_by tool calls
+  /** Citing cases from jade.io citator. All have metadata; top-N have sourceFile. */
+  citedBy?: CitedByRef[];
+  /** ISO timestamp when the cited-by list was last fetched from jade.io. */
+  citedByFetchedAt?: string;
+  /** Total citing-case count reported by jade.io (may exceed citedBy.length). */
+  citedByTotalCount?: number;
 
   // Embedding slot — populated by a future kannon-2 / local-model integration
   embedding?: number[];
@@ -303,6 +335,57 @@ export async function exportBib(cacheDir: string, document?: string): Promise<st
   const entries = await listCitations(cacheDir, document);
   if (entries.length === 0) return "";
   return entries.map(formatBibEntry).join("\n\n");
+}
+
+/**
+ * Replace the citedBy list on an existing cache entry and record when it was
+ * fetched.  Overwrites any prior citedBy array so callers always store the
+ * most recent snapshot from jade.io.
+ *
+ * Note: same load-mutate-save limitation as upsertCitation.
+ */
+export async function updateCitedBy(
+  cacheDir: string,
+  citeKey: string,
+  refs: CitedByRef[],
+  totalCount: number,
+): Promise<void> {
+  const cache = await loadCache(cacheDir);
+  const entry = cache.entries.find((e) => e.citeKey === citeKey);
+  if (!entry) return;
+  entry.citedBy = refs;
+  entry.citedByFetchedAt = new Date().toISOString();
+  entry.citedByTotalCount = totalCount;
+  entry.updatedAt = new Date().toISOString();
+  await saveCache(cacheDir, cache);
+}
+
+/**
+ * Update source-download fields on a specific CitedByRef within a parent entry.
+ * The ref is matched by neutralCitation.
+ *
+ * Note: same load-mutate-save limitation as upsertCitation.
+ */
+export async function updateCitedBySource(
+  cacheDir: string,
+  parentCiteKey: string,
+  refNeutralCitation: string,
+  fields: {
+    sourceFile?: string;
+    sourceFetchedAt?: string;
+    contentHash?: string;
+    sourceEtag?: string;
+    sourceLastModified?: string;
+  },
+): Promise<void> {
+  const cache = await loadCache(cacheDir);
+  const entry = cache.entries.find((e) => e.citeKey === parentCiteKey);
+  if (!entry?.citedBy) return;
+  const ref = entry.citedBy.find((r) => r.neutralCitation === refNeutralCitation);
+  if (!ref) return;
+  Object.assign(ref, fields);
+  entry.updatedAt = new Date().toISOString();
+  await saveCache(cacheDir, cache);
 }
 
 /**

--- a/src/services/citation-cache.ts
+++ b/src/services/citation-cache.ts
@@ -349,12 +349,13 @@ export async function updateCitedBy(
   citeKey: string,
   refs: CitedByRef[],
   totalCount: number,
+  fetchedAt?: string,
 ): Promise<void> {
   const cache = await loadCache(cacheDir);
   const entry = cache.entries.find((e) => e.citeKey === citeKey);
   if (!entry) return;
   entry.citedBy = refs;
-  entry.citedByFetchedAt = new Date().toISOString();
+  entry.citedByFetchedAt = fetchedAt ?? new Date().toISOString();
   entry.citedByTotalCount = totalCount;
   entry.updatedAt = new Date().toISOString();
   await saveCache(cacheDir, cache);

--- a/src/test/unit/cited-by-cache.test.ts
+++ b/src/test/unit/cited-by-cache.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFs = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  mkdir: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  promises: mockFs,
+}));
+
+import {
+  updateCitedBy,
+  updateCitedBySource,
+  type CitedByRef,
+} from "../../services/citation-cache.js";
+
+const CACHE_DIR = "/test/project";
+
+function makeCacheJson(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    version: 1,
+    projectName: "project",
+    entries: [
+      {
+        citeKey: "mabo1992",
+        id: "test-uuid",
+        title: "Mabo v Queensland (No 2)",
+        neutralCitation: "[1992] HCA 23",
+        aglc4Full: "Mabo v Queensland (No 2) [1992] HCA 23",
+        url: "https://www.austlii.edu.au/cgi-bin/viewdoc/au/cases/cth/HCA/1992/23.html",
+        type: "case",
+        documents: [],
+        footnoteNumbers: {},
+        addedAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        bibType: "jurisdiction",
+        bibFields: {},
+        ...overrides,
+      },
+    ],
+  });
+}
+
+const SAMPLE_REFS: CitedByRef[] = [
+  {
+    title: "Wik Peoples v Queensland",
+    neutralCitation: "[1996] HCA 40",
+    aglc4Full: "Wik Peoples v Queensland [1996] HCA 40",
+    url: "https://www.austlii.edu.au/cgi-bin/viewdoc/au/cases/cth/HCA/1996/40.html",
+    year: 1996,
+    court: "HCA",
+  },
+  {
+    title: "Members of the Yorta Yorta Aboriginal Community v Victoria",
+    neutralCitation: "[2002] HCA 58",
+    aglc4Full: "Members of the Yorta Yorta Aboriginal Community v Victoria [2002] HCA 58",
+    url: "https://www.austlii.edu.au/cgi-bin/viewdoc/au/cases/cth/HCA/2002/58.html",
+    year: 2002,
+    court: "HCA",
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFs.mkdir.mockResolvedValue(undefined);
+  mockFs.writeFile.mockResolvedValue(undefined);
+});
+
+describe("updateCitedBy", () => {
+  it("stores citedBy refs and sets citedByFetchedAt", async () => {
+    mockFs.readFile.mockResolvedValueOnce(makeCacheJson());
+
+    await updateCitedBy(CACHE_DIR, "mabo1992", SAMPLE_REFS, 42);
+
+    const written = JSON.parse(mockFs.writeFile.mock.calls[0]![1] as string);
+    const entry = written.entries[0];
+    expect(entry.citedBy).toHaveLength(2);
+    expect(entry.citedBy[0].neutralCitation).toBe("[1996] HCA 40");
+    expect(entry.citedByFetchedAt).toBeDefined();
+    expect(entry.citedByTotalCount).toBe(42);
+  });
+
+  it("replaces an existing citedBy array rather than appending", async () => {
+    mockFs.readFile.mockResolvedValueOnce(
+      makeCacheJson({ citedBy: [{ title: "Old Case", neutralCitation: "[2000] HCA 1" }] }),
+    );
+
+    await updateCitedBy(CACHE_DIR, "mabo1992", SAMPLE_REFS, 2);
+
+    const written = JSON.parse(mockFs.writeFile.mock.calls[0]![1] as string);
+    expect(written.entries[0].citedBy).toHaveLength(2);
+    expect(written.entries[0].citedBy[0].neutralCitation).toBe("[1996] HCA 40");
+  });
+
+  it("updates the parent entry's updatedAt timestamp", async () => {
+    mockFs.readFile.mockResolvedValueOnce(makeCacheJson());
+
+    await updateCitedBy(CACHE_DIR, "mabo1992", SAMPLE_REFS, 2);
+
+    const written = JSON.parse(mockFs.writeFile.mock.calls[0]![1] as string);
+    expect(written.entries[0].updatedAt).not.toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("does nothing when citeKey is not found", async () => {
+    mockFs.readFile.mockResolvedValueOnce(
+      JSON.stringify({ version: 1, projectName: "p", entries: [] }),
+    );
+
+    await updateCitedBy(CACHE_DIR, "nonexistent", SAMPLE_REFS, 0);
+
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("handles empty refs array (clears prior data)", async () => {
+    mockFs.readFile.mockResolvedValueOnce(
+      makeCacheJson({ citedBy: SAMPLE_REFS, citedByTotalCount: 2 }),
+    );
+
+    await updateCitedBy(CACHE_DIR, "mabo1992", [], 0);
+
+    const written = JSON.parse(mockFs.writeFile.mock.calls[0]![1] as string);
+    expect(written.entries[0].citedBy).toHaveLength(0);
+    expect(written.entries[0].citedByTotalCount).toBe(0);
+  });
+});
+
+describe("updateCitedBySource", () => {
+  it("updates sourceFile and related fields on a matching CitedByRef", async () => {
+    mockFs.readFile.mockResolvedValueOnce(makeCacheJson({ citedBy: SAMPLE_REFS }));
+
+    await updateCitedBySource(CACHE_DIR, "mabo1992", "[1996] HCA 40", {
+      sourceFile: "sources/mabo1992_citing_1996_hca_40.md",
+      sourceFetchedAt: "2026-01-02T00:00:00.000Z",
+      contentHash: "abc123",
+      sourceEtag: '"etag-wik"',
+      sourceLastModified: "Wed, 01 Jan 2026 00:00:00 GMT",
+    });
+
+    const written = JSON.parse(mockFs.writeFile.mock.calls[0]![1] as string);
+    const ref = written.entries[0].citedBy[0];
+    expect(ref.sourceFile).toBe("sources/mabo1992_citing_1996_hca_40.md");
+    expect(ref.contentHash).toBe("abc123");
+    expect(ref.sourceEtag).toBe('"etag-wik"');
+  });
+
+  it("updates the parent entry's updatedAt timestamp", async () => {
+    mockFs.readFile.mockResolvedValueOnce(makeCacheJson({ citedBy: SAMPLE_REFS }));
+
+    await updateCitedBySource(CACHE_DIR, "mabo1992", "[1996] HCA 40", {
+      sourceFile: "sources/wik.md",
+    });
+
+    const written = JSON.parse(mockFs.writeFile.mock.calls[0]![1] as string);
+    expect(written.entries[0].updatedAt).not.toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("does nothing when parent citeKey is not found", async () => {
+    mockFs.readFile.mockResolvedValueOnce(
+      JSON.stringify({ version: 1, projectName: "p", entries: [] }),
+    );
+
+    await updateCitedBySource(CACHE_DIR, "nonexistent", "[1996] HCA 40", {
+      sourceFile: "sources/wik.md",
+    });
+
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when citedBy array is absent on the parent", async () => {
+    mockFs.readFile.mockResolvedValueOnce(makeCacheJson());
+
+    await updateCitedBySource(CACHE_DIR, "mabo1992", "[1996] HCA 40", {
+      sourceFile: "sources/wik.md",
+    });
+
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the neutralCitation is not found in citedBy", async () => {
+    mockFs.readFile.mockResolvedValueOnce(makeCacheJson({ citedBy: SAMPLE_REFS }));
+
+    await updateCitedBySource(CACHE_DIR, "mabo1992", "[9999] HCA 999", {
+      sourceFile: "sources/unknown.md",
+    });
+
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("only updates the matched ref, leaving others unchanged", async () => {
+    mockFs.readFile.mockResolvedValueOnce(makeCacheJson({ citedBy: SAMPLE_REFS }));
+
+    await updateCitedBySource(CACHE_DIR, "mabo1992", "[1996] HCA 40", {
+      sourceFile: "sources/wik.md",
+    });
+
+    const written = JSON.parse(mockFs.writeFile.mock.calls[0]![1] as string);
+    const refs: CitedByRef[] = written.entries[0].citedBy;
+    expect(refs[0]!.sourceFile).toBe("sources/wik.md");
+    expect(refs[1]!.sourceFile).toBeUndefined();
+  });
+});
+
+describe("CachedCitation — citedBy fields round-trip", () => {
+  it("persists all CitedByRef fields through save and load", async () => {
+    const refsWithSource: CitedByRef[] = [
+      {
+        ...SAMPLE_REFS[0]!,
+        sourceFile: "sources/mabo1992_citing_1996_hca_40.md",
+        sourceFetchedAt: "2026-01-02T00:00:00.000Z",
+        contentHash: "deadbeef",
+        sourceEtag: '"etag-wik"',
+        sourceLastModified: "Wed, 01 Jan 2026 00:00:00 GMT",
+      },
+    ];
+
+    mockFs.readFile.mockResolvedValueOnce(
+      makeCacheJson({
+        citedBy: refsWithSource,
+        citedByFetchedAt: "2026-01-02T00:00:00.000Z",
+        citedByTotalCount: 500,
+      }),
+    );
+
+    // Trigger a no-op write to inspect round-trip
+    await updateCitedBy(CACHE_DIR, "mabo1992", refsWithSource, 500);
+
+    const written = JSON.parse(mockFs.writeFile.mock.calls[0]![1] as string);
+    const entry = written.entries[0];
+    expect(entry.citedByTotalCount).toBe(500);
+    const ref = entry.citedBy[0];
+    expect(ref.contentHash).toBe("deadbeef");
+    expect(ref.sourceEtag).toBe('"etag-wik"');
+    expect(ref.sourceLastModified).toBe("Wed, 01 Jan 2026 00:00:00 GMT");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `citedBy` relationship layer to the local citation cache: each `CachedCitation` entry can now hold a snapshot of cases that cite it, sourced from jade.io's citator
- Stores metadata for **all** cited-by results and downloads the full source text for the **top N** (default 5), with the same ETag/Last-Modified freshness tracking used for primary sources
- Three new env vars control behaviour (all default-on):
  - `AUSLAW_CACHE_CITED_BY` — toggle caching entirely
  - `AUSLAW_DOWNLOAD_CITED_BY_SOURCES` — toggle source download
  - `AUSLAW_CITED_BY_DOWNLOAD_LIMIT` — max sources to download per lookup (default `5`)

## New MCP tools

| Tool | Description |
|------|-------------|
| `cache_cited_by` | Fetch citing cases from jade.io and store them. Downloads top-N sources. Requires `JADE_SESSION_COOKIE`. |
| `get_cited_by` | Return the cached cited-by list for a cite key. Zero network calls. |

## New cache functions (`citation-cache.ts`)

- `updateCitedBy(cacheDir, citeKey, refs, totalCount)` — replaces the `citedBy` array; records `citedByFetchedAt` and `citedByTotalCount`
- `updateCitedBySource(cacheDir, parentCiteKey, refNeutralCitation, fields)` — patches source-download fields on a single `CitedByRef`

## `CitedByRef` schema

Stores: `title`, `neutralCitation`, `aglc4Full`, `url` (AustLII if derivable, otherwise jade.io), `year`, `court`, plus `sourceFile` / `sourceFetchedAt` / `contentHash` / `sourceEtag` / `sourceLastModified` once downloaded.

## Test plan

- [ ] 19 test files, 312 tests pass, 0 lint errors
- [ ] `updateCitedBy`: stores refs, sets `citedByFetchedAt`/`citedByTotalCount`, replaces (not appends), no-op on missing citeKey, clears on empty array
- [ ] `updateCitedBySource`: patches matched ref, leaves others untouched, no-op on missing parent/ref/array
- [ ] Round-trip: all `CitedByRef` source fields survive save/load cycle
- [ ] Manual: call `cache_cited_by` with a cached citeKey, verify `.auslaw/citations.json` gains `citedBy` array and `sourcesDownloaded` count returned correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6KyQJcwEDwDQq7SrX7Cna)_

<!-- greptile_comment -->

[Greptile](https://greptile.com)
---

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `citedBy` relationship layer to the local citation cache, sourced from jade.io's citator. Two new MCP tools (`cache_cited_by`, `get_cited_by`) let callers fetch and retrieve citing-case metadata and optionally download the top-N source files, with ETag/Last-Modified conditional-GET freshness tracking and three env-var controls.

Previous review concerns have been addressed in this revision: the `|| 5` NaN guard is present on `downloadLimit`, `priorSources` is snapshotted before `updateCitedBy` overwrites the array (restoring the ETag conditional-GET path), a single `now` variable is shared across `updateCitedBy` and the response JSON (eliminating the timestamp divergence), `get_cited_by` restricts its `format` enum to `[\"json\", \"markdown\"]`, and an explicit guard returns a preserved-cache error when jade.io returns empty results but prior data exists.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all prior P0/P1 findings have been addressed in this revision.

All five previously identified issues (NaN guard, ETag conditional-GET path, timestamp divergence, format enum restriction, empty-result data-loss guard) are resolved. No new correctness or security issues were found. Test coverage is thorough for the new cache functions.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/config.ts | Adds `citedBy` config block with three env-var controls; `downloadLimit` uses `parseInt(...) || 5` to guard against NaN. |
| src/services/citation-cache.ts | Adds `CitedByRef` interface and `citedBy*` fields on `CachedCitation`; `updateCitedBy` and `updateCitedBySource` follow the existing load-mutate-save pattern correctly. |
| src/index.ts | Registers `cache_cited_by` and `get_cited_by` tools; `priorSources` snapshot before `updateCitedBy` preserves ETag data; `now` timestamp shared across cache write and response; session-cookie guard prevents empty-result data loss. |
| src/test/unit/cited-by-cache.test.ts | New unit tests cover all `updateCitedBy` and `updateCitedBySource` branches, including no-op cases and round-trip field persistence. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant cache_cited_by
    participant jade.io
    participant CitationCache
    participant SourceStore

    Caller->>cache_cited_by: citeKey
    cache_cited_by->>CitationCache: getCitation(citeKey)
    CitationCache-->>cache_cited_by: parent (with optional prior citedBy)
    Note over cache_cited_by: Snapshot priorSources Map<neutralCitation, CitedByRef>
    cache_cited_by->>jade.io: searchCitingCases(neutralCitation ?? title)
    jade.io-->>cache_cited_by: { results, totalCount }
    alt empty results + prior data exists
        cache_cited_by-->>Caller: error (cookie may be expired, cache preserved)
    else results available (or genuinely empty on first call)
        cache_cited_by->>CitationCache: updateCitedBy(refs, totalCount, now)
        loop top-N refs with url + neutralCitation
            cache_cited_by->>SourceStore: storeSource(fileKey, url, priorSources.get(ref.neutralCitation))
            Note over SourceStore: Conditional GET via ETag/Last-Modified if prior exists
            SourceStore-->>cache_cited_by: { path, contentHash, etag, lastModified }
            cache_cited_by->>CitationCache: updateCitedBySource(neutralCitation, sourceFields)
        end
        cache_cited_by-->>Caller: { citeKey, totalCount, cached, sourcesDownloaded, citedByFetchedAt }
    end
```

<sub>Reviews (3): Last reviewed commit: ["Guard cache\_cited\_by against erasing dat..."](https://github.com/russellbrenner/auslaw-mcp/commit/986a000cbf34e930800fcba0c6b3a834fa1a962b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30466752)</sub>

<!-- /greptile_comment -->