### PR TITLE
Support direct npx launch from git URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Model Context Protocol (MCP) server for Australian and New Zealand legal researc
 ## Features
 
 ### Current Capabilities
+
 - ✅ **Case law search**: Natural language queries across all Australian and NZ jurisdictions
 - ✅ **All jurisdictions**: Commonwealth, all States/Territories (VIC, NSW, QLD, SA, WA, TAS, NT, ACT), and New Zealand
 - ✅ **Intelligent search relevance**: Auto-detects case name queries vs topic searches
@@ -37,16 +38,26 @@ See [docs/ROADMAP.md](docs/ROADMAP.md) for the full development history and futu
 
 ## Documentation
 
-| Document | Description |
-|----------|-------------|
-| [ARCHITECTURE.md](docs/ARCHITECTURE.md) | System architecture, deployment topology, CI/CD pipeline, production patterns |
-| [DECISIONS.md](docs/DECISIONS.md) | Architectural decision records (ADRs) with context and consequences |
-| [AGENT-GUIDE.md](docs/AGENT-GUIDE.md) | Agent-facing usage guide with tool catalog and examples |
-| [DOCKER.md](docs/DOCKER.md) | Docker deployment guide |
-| [ROADMAP.md](docs/ROADMAP.md) | Development history and future plans |
-| [jade-gwt-protocol.md](docs/jade-gwt-protocol.md) | jade.io GWT-RPC reverse-engineering details |
+| Document                                          | Description                                                                   |
+| ------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [ARCHITECTURE.md](docs/ARCHITECTURE.md)           | System architecture, deployment topology, CI/CD pipeline, production patterns |
+| [DECISIONS.md](docs/DECISIONS.md)                 | Architectural decision records (ADRs) with context and consequences           |
+| [AGENT-GUIDE.md](docs/AGENT-GUIDE.md)             | Agent-facing usage guide with tool catalog and examples                       |
+| [DOCKER.md](docs/DOCKER.md)                       | Docker deployment guide                                                       |
+| [ROADMAP.md](docs/ROADMAP.md)                     | Development history and future plans                                          |
+| [jade-gwt-protocol.md](docs/jade-gwt-protocol.md) | jade.io GWT-RPC reverse-engineering details                                   |
 
 ## Quick Start
+
+### Run with npx (no local clone required)
+
+```bash
+npx -y github:russellbrenner/auslaw-mcp
+```
+
+`npx` clones the repository, installs dependencies, builds, and launches the
+MCP server over stdio in one step. Use this for the simplest install path or
+when configuring an MCP-compatible client (see [MCP Registration](#mcp-registration)).
 
 ### Local Development
 
@@ -58,6 +69,7 @@ npm run dev  # hot reload for local development
 ```
 
 To build for production:
+
 ```bash
 npm run build
 npm start
@@ -92,9 +104,31 @@ kubectl apply -f k8s/
 See [k8s/README.md](k8s/README.md) for complete Kubernetes deployment guide.
 
 ## MCP Registration
-Configure your MCP-compatible client (eg. Claude Desktop, Cursor) to launch the compiled server.
+
+Configure your MCP-compatible client (eg. Claude Desktop, Cursor, Claude Code)
+to launch the server.
+
+### Option A — npx (no clone required)
+
+```json
+{
+  "mcpServers": {
+    "auslaw-mcp": {
+      "command": "npx",
+      "args": ["-y", "github:russellbrenner/auslaw-mcp"]
+    }
+  }
+}
+```
+
+The first invocation clones the repo, installs deps, and builds. Subsequent
+launches reuse the cached install. To pin to a specific commit or branch,
+append `#<ref>` to the URL — eg. `github:russellbrenner/auslaw-mcp#main`.
+
+### Option B — Local clone
 
 For Claude Desktop, edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
 ```json
 {
   "mcpServers": {
@@ -179,6 +213,7 @@ Once the MCP is connected, you can ask an AI assistant like Claude natural langu
 ## Available Tools
 
 ### search_cases
+
 Search Australian and New Zealand case law.
 
 **Parameters:**
@@ -206,6 +241,7 @@ Search Australian and New Zealand case law.
 **Examples:**
 
 Find a specific case:
+
 ```json
 {
   "query": "Donoghue v Stevenson",
@@ -215,6 +251,7 @@ Find a specific case:
 ```
 
 Recent NSW cases on a topic:
+
 ```json
 {
   "query": "adverse possession",
@@ -225,6 +262,7 @@ Recent NSW cases on a topic:
 ```
 
 Exact phrase search:
+
 ```json
 {
   "query": "duty of care",
@@ -235,6 +273,7 @@ Exact phrase search:
 ```
 
 Pagination (get results 51-100):
+
 ```json
 {
   "query": "contract breach",
@@ -244,6 +283,7 @@ Pagination (get results 51-100):
 ```
 
 ### search_legislation
+
 Search Australian and New Zealand legislation.
 
 **Parameters:**
@@ -258,6 +298,7 @@ Search Australian and New Zealand legislation.
 | `format` | No | `json` (default), `text`, `markdown`, `html` |
 
 **Example:**
+
 ```json
 {
   "query": "Privacy Act",
@@ -268,6 +309,7 @@ Search Australian and New Zealand legislation.
 ```
 
 ### fetch_document_text
+
 Fetch full text from a case or legislation URL. Supports AustLII HTML, PDF with OCR fallback, and jade.io authenticated fetch via GWT-RPC (requires `JADE_SESSION_COOKIE`).
 
 **Parameters:**
@@ -277,6 +319,7 @@ Fetch full text from a case or legislation URL. Supports AustLII HTML, PDF with 
 | `format` | No | `json` (default), `text`, `markdown`, `html` |
 
 **Example:**
+
 ```json
 {
   "url": "https://www.austlii.edu.au/cgi-bin/viewdoc/au/cases/cth/HCA/1992/23.html"
@@ -284,6 +327,7 @@ Fetch full text from a case or legislation URL. Supports AustLII HTML, PDF with 
 ```
 
 ### format_citation
+
 Format an Australian case citation per AGLC4 rules.
 
 **Parameters:**
@@ -296,6 +340,7 @@ Format an Australian case citation per AGLC4 rules.
 | `style` | No | `combined` (default), `neutral`, or `reported` |
 
 **Example:**
+
 ```json
 {
   "title": "Mabo v Queensland (No 2)",
@@ -308,6 +353,7 @@ Format an Australian case citation per AGLC4 rules.
 **Output:** `Mabo v Queensland (No 2) [1992] HCA 23, (1992) 175 CLR 1 at [64]`
 
 ### validate_citation
+
 Validate a neutral citation by checking it exists on AustLII.
 
 **Parameters:**
@@ -318,6 +364,7 @@ Validate a neutral citation by checking it exists on AustLII.
 **Returns:** `{ valid, canonicalCitation, austliiUrl, message }`
 
 ### generate_pinpoint
+
 Fetch a judgment from AustLII and generate a pinpoint citation to a specific paragraph.
 
 **Parameters:**
@@ -328,9 +375,10 @@ Fetch a judgment from AustLII and generate a pinpoint citation to a specific par
 | `phrase` | No* | Phrase to search for within paragraphs |
 | `caseCitation` | No | Case citation to prepend (e.g. `[1992] HCA 23`) |
 
-*At least one of `paragraphNumber` or `phrase` is required.
+\*At least one of `paragraphNumber` or `phrase` is required.
 
 **Example:**
+
 ```json
 {
   "url": "https://www.austlii.edu.au/cgi-bin/viewdoc/au/cases/cth/HCA/1992/23.html",
@@ -342,6 +390,7 @@ Fetch a judgment from AustLII and generate a pinpoint citation to a specific par
 **Output:** `{ paragraphNumber: 64, pinpointString: "at [64]", fullCitation: "[1992] HCA 23 at [64]" }`
 
 ### search_by_citation
+
 Find a case by its citation. If a neutral citation is detected, validates against AustLII directly; otherwise falls back to text search.
 
 **Parameters:**
@@ -351,6 +400,7 @@ Find a case by its citation. If a neutral citation is detected, validates agains
 | `format` | No | `json` (default), `text`, `markdown`, `html` |
 
 ### resolve_jade_article
+
 Resolve metadata for a jade.io article by its numeric ID.
 
 **Parameters:**
@@ -359,6 +409,7 @@ Resolve metadata for a jade.io article by its numeric ID.
 | `articleId` | Yes | jade.io article ID (integer) |
 
 ### jade_citation_lookup
+
 Generate a jade.io lookup URL for a given neutral citation.
 
 **Parameters:**
@@ -368,27 +419,29 @@ Generate a jade.io lookup URL for a given neutral citation.
 
 ## Jurisdictions
 
-| Code | Jurisdiction |
-|------|-------------|
-| `cth` | Commonwealth of Australia |
+| Code      | Jurisdiction                   |
+| --------- | ------------------------------ |
+| `cth`     | Commonwealth of Australia      |
 | `federal` | Federal courts (alias for cth) |
-| `vic` | Victoria |
-| `nsw` | New South Wales |
-| `qld` | Queensland |
-| `sa` | South Australia |
-| `wa` | Western Australia |
-| `tas` | Tasmania |
-| `nt` | Northern Territory |
-| `act` | Australian Capital Territory |
-| `nz` | New Zealand |
-| `other` | All jurisdictions (no filter) |
+| `vic`     | Victoria                       |
+| `nsw`     | New South Wales                |
+| `qld`     | Queensland                     |
+| `sa`      | South Australia                |
+| `wa`      | Western Australia              |
+| `tas`     | Tasmania                       |
+| `nt`      | Northern Territory             |
+| `act`     | Australian Capital Territory   |
+| `nz`      | New Zealand                    |
+| `other`   | All jurisdictions (no filter)  |
 
 ## Running Tests
+
 ```bash
 npm test
 ```
 
 Test scenarios include:
+
 1. **Negligence and duty of care** - Personal injury law searches
 2. **Contract disputes** - Commercial law and breach of contract
 3. **Constitutional law** - High Court constitutional matters
@@ -444,6 +497,7 @@ docs/                     # Architecture, Docker, and roadmap docs
 ### Docker
 
 Quick start:
+
 ```bash
 ./build.sh              # Build Docker image
 docker-compose up       # Run locally
@@ -454,6 +508,7 @@ See [docs/DOCKER.md](docs/DOCKER.md) for detailed Docker deployment instructions
 ### Kubernetes (k3s)
 
 Quick start:
+
 ```bash
 ./build.sh              # Build and export image
 # Import to k3s nodes (see k8s/README.md)
@@ -512,11 +567,13 @@ Then reference it in your deployment manifest via `envFrom` or `env[].valueFrom.
 This project retrieves legal data from publicly accessible databases.
 
 ### AustLII (Australasian Legal Information Institute)
+
 - Website: https://www.austlii.edu.au
 - Terms of Use: https://www.austlii.edu.au/austlii/terms.html
 - AustLII provides free access to Australian and New Zealand legal materials
 
 ### jade.io
+
 - Users must have their own jade.io subscription
 - This tool does not bypass jade.io's access controls
 - Respects jade.io's terms of service
@@ -524,6 +581,7 @@ This project retrieves legal data from publicly accessible databases.
 ### Fair Use
 
 Please use this tool responsibly:
+
 - Implement reasonable delays between requests
 - Cache results when appropriate
 - Don't overload public legal databases
@@ -534,6 +592,7 @@ Please use this tool responsibly:
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full contribution guidelines, [AGENTS.md](AGENTS.md) for AI agent instructions, and [SECURITY.md](SECURITY.md) for responsible disclosure.
 
 **Key principles**:
+
 - Primary sources only (no journal articles)
 - Citation accuracy is paramount
 - All tests must pass before committing

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
         "tmp": "^0.2.5",
         "zod": "^3.25.76"
       },
+      "bin": {
+        "auslaw-mcp": "dist/index.js"
+      },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "format:check": "prettier --check \"src/**/*.ts\"",
     "docs": "typedoc",
     "docs:serve": "npx serve docs/api",
-    "prepare": "(husky || exit 0) && npm run build"
+    "prepare": "(husky || exit 0) && node -e \"const p=require('path'),cp=require('child_process');if(process.env.INIT_CWD&&p.resolve(process.env.INIT_CWD)!==process.cwd())cp.execSync('npm run build',{stdio:'inherit'})\""
   },
   "keywords": [
     "model-context-protocol",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "0.1.0",
   "description": "Model Context Protocol server for Australian legislation and case law search with OCR fallbacks.",
   "main": "dist/index.js",
+  "bin": {
+    "auslaw-mcp": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",
@@ -17,7 +25,7 @@
     "format:check": "prettier --check \"src/**/*.ts\"",
     "docs": "typedoc",
     "docs:serve": "npx serve docs/api",
-    "prepare": "husky"
+    "prepare": "(husky || exit 0) && npm run build"
   },
   "keywords": [
     "model-context-protocol",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";


### PR DESCRIPTION
## Summary

Adds the wiring to launch `auslaw-mcp` directly via `npx` (or any
git-URL install) without a manual clone/build step.

```bash
npx -y github:russellbrenner/auslaw-mcp
```

This mirrors how most published MCP servers expect to be invoked from
Claude Desktop / Claude Code / Cursor configs, so the README's MCP
Registration section now offers an `npx`-based config alongside the
existing local-path one.

## Changes

**`fcfc835` — `feat: support npx launch from git URL`** (3 files,
~13 lines net)

- `package.json`
  - Adds `bin: { "auslaw-mcp": "dist/index.js" }` so `npx`/`npm exec`
    can resolve the executable.
  - Adds `files: ["dist", "README.md", "LICENSE"]` whitelist for any
    future npm publish (no behavioural impact for git installs).
  - Updates `prepare` from `husky` to
    `(husky || exit 0) && npm run build`, so a git-URL install
    populates `dist/` before npm/npx looks for the bin. The
    `|| exit 0` guards the case where husky isn't usable inside an
    npm cache install with no `.git`. Inline shim chosen over a
    `scripts/prepare.js` to keep the PR transparent — the whole
    behaviour is one line in `package.json`.
- `src/index.ts`
  - Adds `#!/usr/bin/env node` shebang. TypeScript preserves the
    shebang in compiled output and sets the `+x` bit on POSIX, both
    of which `npm`'s bin-linking relies on.
- `package-lock.json`
  - Auto-regenerated `bin` entry to match `package.json`.

**`d5e49ac` — `docs: document npx launch path`** (README.md)

- Adds a "Run with npx" subsection to Quick Start.
- Splits MCP Registration into Option A (npx) and Option B (local
  clone) with config snippets for both.
- Note: lint-staged ran `prettier --write` on the staged README on
  commit, which reformatted the existing Documentation table and
  added blank-after-heading spacing in pre-existing sections. The
  substantive additions are the new npx headings and code blocks;
  the rest is bringing the file into compliance with the project's
  declared Prettier config (the upstream `main` README is currently
  not Prettier-compliant — `prettier --check` flags 39 files).
  Happy to split that into a separate `chore: format README` commit
  if preferred.

## Test plan

- [x] `npm install` runs `prepare` cleanly (husky + tsc, no errors)
- [x] `dist/index.js` has the shebang and is executable
- [x] `npm exec auslaw-mcp` resolves the bin and launches the stdio
      server
- [x] `npx -y "github:mickey-mikey/auslaw-mcp#fix-npx-launch"` from a
      clean directory clones, installs, builds, and serves —
      verified end-to-end by sending an MCP `initialize` request and
      receiving a valid `serverInfo: auslaw-mcp 0.1.0` response with
      `tools.listChanged` capability
- [x] Registered in a Claude Code session via the npx command form
      and confirmed all 18 tools load and `format_citation` /
      `resolve_jade_article` return correct results
- [x] `npm run build` clean
- [x] `npm run lint` clean (8 pre-existing warnings in
      `src/test/citator.test.ts`, untouched)
- [x] `npm test` produces the same 22 failures with or without this
      branch's changes — pre-existing breakage in
      `source-store.test.ts` (Windows path separators) and
      `search-performance.test.ts` (AustLII Cloudflare 403). No new
      failures introduced
- [x] `npm run format:check` — my edits do not introduce new
      warnings (the docs commit reformats README to match the
      project's Prettier config)

## PR Template Checklist

- [ ] Tests added/updated — N/A; the change is structural metadata
      (`bin` field + shebang + `prepare` shim). No reasonable unit
      test would exercise it without re-running the npm install
      pipeline against the working tree
- [x] Documentation updated (README.md, both Quick Start and MCP
      Registration sections)
- [x] Code follows style guidelines
- [x] All CI checks pass (subject to the same pre-existing failures
      seen on `main`)
- [x] No breaking changes — the existing local-clone path is
      unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

[Greptile](https://greptile.com)
---

<h3>Greptile Summary</h3>

This PR wires up `npx -y github:russellbrenner/auslaw-mcp` as a first-class launch path by adding a `bin` entry, a `files` whitelist, a shebang to `src/index.ts`, and a conditional `prepare` build step that fires only on git-URL/`npx` installs (detected via `INIT_CWD`). The implementation is correct and well-tested; the `node -e` inline script uses CJS `require()` safely because Node.js always evaluates `--eval` strings as CommonJS regardless of a nearby `"type": "module"` field.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are purely structural metadata with no behavioural impact on existing workflows

All four changed files are clean. The INIT_CWD heuristic correctly gates the build to git-URL installs only; the node -e CJS require() is safe under all supported Node.js versions; the shebang is handled correctly by TypeScript 5.x. The one P2 note (missing prepack guard for future npm publish) has no impact on the current release path.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | Adds `bin`, `files`, and reworks `prepare` to conditionally build via `INIT_CWD` heuristic; logic is correct for npm/npx git-URL installs |
| src/index.ts | Adds `#!/usr/bin/env node` shebang on line 1; TypeScript 5.x preserves this in compiled output |
| README.md | Documents npx launch path and splits MCP Registration into Option A (npx) and Option B (local clone); Prettier reformatting of pre-existing content |
| package-lock.json | Auto-regenerated to add `bin` entry matching the new `package.json` field |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User / MCP Client
    participant NX as npx
    participant NPM as npm install
    participant P as prepare script
    participant TSC as tsc (build)
    participant BIN as dist/index.js

    U->>NX: npx -y github:russellbrenner/auslaw-mcp
    NX->>NPM: install from git URL (incl. devDeps)
    NPM->>P: run lifecycle: prepare
    P->>P: husky || exit 0
    P->>P: INIT_CWD !== cwd()?
    alt git-URL / npx install
        P->>TSC: npm run build
        TSC-->>BIN: dist/index.js (with shebang)
    else local npm install
        P-->>P: skip build
    end
    NPM-->>NX: bin linked → auslaw-mcp → dist/index.js
    NX-->>U: launch stdio MCP server
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackage.json%3A28%0A**%60prepare%60%20won't%20auto-build%20on%20%60npm%20publish%60%20from%20a%20local%20checkout**%0A%0ABecause%20%60INIT_CWD%20%3D%3D%3D%20process.cwd%28%29%60%20when%20running%20%60npm%20publish%60%20from%20the%20project%20root%2C%20the%20build%20step%20inside%20the%20%60prepare%60%20script%20is%20skipped.%20If%20%60dist%2F%60%20is%20stale%20or%20absent%20at%20publish%20time%2C%20the%20package%20will%20be%20published%20without%20a%20built%20binary.%20This%20is%20safe%20today%20%28no%20npm%20publish%20yet%29%2C%20but%20worth%20knowing%20before%20cutting%20a%20first%20release.%0A%0AA%20guard%20in%20%60prepack%60%20%28which%20fires%20unconditionally%20before%20%60npm%20pack%60%2F%60npm%20publish%60%29%20would%20cover%20this%20case%3A%0A%0A%60%60%60json%0A%22prepack%22%3A%20%22npm%20run%20build%22%0A%60%60%60%0A%0A&repo=russellbrenner%2Fauslaw-mcp&pr=82&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
package.json:28
**`prepare` won't auto-build on `npm publish` from a local checkout**

Because `INIT_CWD === process.cwd()` when running `npm publish` from the project root, the build step inside the `prepare` script is skipped. If `dist/` is stale or absent at publish time, the package will be published without a built binary. This is safe today (no npm publish yet), but worth knowing before cutting a first release.

A guard in `prepack` (which fires unconditionally before `npm pack`/`npm publish`) would cover this case:

```json
"prepack": "npm run build"
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: skip prepare-build during dev insta..."](https://github.com/russellbrenner/auslaw-mcp/commit/9f4987dffb4ddea1395bc308e828cd6f4fbad00b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30542175)</sub>

<!-- /greptile_comment -->