### PR TITLE
fix: make project-scoped .mcp.json portable

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,9 +3,7 @@
     "auslaw-mcp": {
       "type": "stdio",
       "command": "node",
-      "args": [
-        "/Users/rbrenner/git/auslaw-mcp/dist/index.js"
-      ],
+      "args": ["dist/index.js"],
       "env": {}
     }
   }


### PR DESCRIPTION
## Summary

- `.mcp.json` (added in 7345b4a) hardcoded an absolute macOS path (`/Users/rbrenner/git/auslaw-mcp/dist/index.js`), so Claude Code failed to launch the server on any other machine — `claude mcp list` reports `auslaw-mcp ... ✗ Failed to connect`.
- This swaps it for a relative path (`dist/index.js`). Project-scoped MCP configs are spawned with cwd at the project root, so the launch resolves cross-platform without changing the launch semantics.
- Independent of #82 — that PR adds an npx-from-git path for end users; this fixes the dev-time config so contributors get a working MCP from a fresh clone.

## Notes

- Contributors still need to `npm run build` before launching Claude Code in this directory; no change to that workflow.
- Considered `npm start` as an alternative (also cwd-tolerant) but chose the minimal-diff form to preserve the original `command: "node"` choice. Happy to switch if preferred.

## Test plan

- [ ] `npm run build` produces `dist/index.js`
- [ ] `node dist/index.js` from the project root starts the stdio server (no path error)
- [ ] Open the project in Claude Code; `claude mcp list` shows `auslaw-mcp ... ✓ Connected`
- [ ] Verified on Windows; macOS/Linux equivalents would behave identically (relative resolution from cwd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

[Greptile](https://greptile.com)
---

<h3>Greptile Summary</h3>

Replaces a hardcoded absolute macOS path (`/Users/rbrenner/git/auslaw-mcp/dist/index.js`) in `.mcp.json` with the relative path `dist/index.js`, making the project-scoped MCP config portable across machines. Also adds a missing newline at end of file. The fix is correct — Claude Code launches project-scoped MCP servers with cwd set to the project root, so the relative path resolves as expected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line config fix with no logic, security, or runtime concerns.

The change is a one-line path correction in a JSON config file. The relative path is the idiomatic approach for project-scoped MCP configs, the reasoning in the PR description is sound, and there are no code-logic, security, or compatibility issues.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .mcp.json | Swaps absolute machine-specific path for a relative path and adds missing newline at EOF — correct and minimal fix. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant CC as Claude Code
    participant MCP as .mcp.json
    participant Node as node process

    Dev->>CC: Open project in Claude Code
    CC->>MCP: Read project-scoped .mcp.json
    Note over MCP: cwd = project root
    MCP-->>CC: command: "node", args: ["dist/index.js"]
    CC->>Node: spawn node dist/index.js (cwd = project root)
    Node-->>CC: stdio MCP server connected ✓
```

<sub>Reviews (1): Last reviewed commit: ["fix: use relative path in project-scoped..."](https://github.com/russellbrenner/auslaw-mcp/commit/e628a8f3abd7daca5b06714ab9f1a4471ca00139) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30542900)</sub>

<!-- /greptile_comment -->