### PR TITLE
feat: load .env on startup via dotenv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ AUSTLII_TIMEOUT=60000
 JADE_BASE_URL=https://jade.io
 JADE_USER_AGENT=auslaw-mcp/0.1.0 (legal research tool)
 JADE_TIMEOUT=15000
+# JADE_SESSION_COOKIE=IID=...; alcsessionid=...; cf_clearance=...
+# (Required for authenticated jade.io fetch and search. See README "jade.io Authenticated Access".)
 
 # OCR Configuration
 OCR_LANGUAGE=eng

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.15.2",
         "cheerio": "^1.1.2",
+        "dotenv": "^17.4.2",
         "file-type": "^21.3.0",
         "pdf-parse": "^2.4.5",
         "tmp": "^0.2.5",
@@ -2726,6 +2727,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.15.2",
     "cheerio": "^1.1.2",
+    "dotenv": "^17.4.2",
     "file-type": "^21.3.0",
     "pdf-parse": "^2.4.5",
     "tmp": "^0.2.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import "dotenv/config";
+
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";


### PR DESCRIPTION
## Summary

- Adds `dotenv` and a side-effect `import "dotenv/config"` at the top of `src/index.ts`. The server now populates `process.env` from a project-root `.env` before `config.ts` reads `JADE_SESSION_COOKIE` (and the rest of the env-driven config).
- Makes the existing `.env.example` template actually load: `cp .env.example .env`, fill in values, and Claude Code / `npm start` / `npm run dev` pick them up automatically.
- `.env` and `.env.*.local` are already in `.gitignore`, so no secrets land in version control.
- No behaviour change when `.env` is absent — dotenv is silent on a missing file.

## Why

Right now contributors have to either inline secrets into a committed `.mcp.json` env block, set persistent shell env vars, or wire up their own dotenv loader. The `.env.example` file implies the project supports `.env`, but nothing actually loads it.

## Notes

- Runtime entrypoint only — vitest still doesn't see `.env` unless `dotenv/config` is added to its `setupFiles`. Happy to do that as a follow-up if desired; left out here to keep the change minimal.
- Independent of #82 (npx-launch) and #83 (.mcp.json portability).

## Test plan

- [x] `npm install` — `dotenv ^17.4.2` added
- [x] `npm run build` — clean, dotenv import preserved as first line of `dist/index.js`
- [x] Manual smoke test: with `JADE_SESSION_COOKIE` removed from the parent shell and only present in `.env`, `node -e 'require("dotenv/config"); console.log(!!process.env.JADE_SESSION_COOKIE)'` returns `true`
- [ ] Existing unit tests still pass (`npx vitest run src/test/unit/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

[Greptile](https://greptile.com)
---

<h3>Greptile Summary</h3>

This PR adds `dotenv ^17.4.2` as a runtime dependency and inserts `import "dotenv/config"` as the first line of `src/index.ts`, ensuring a project-root `.env` file is loaded into `process.env` before `config.ts` reads any environment variables. It also adds the previously-missing `JADE_SESSION_COOKIE` placeholder to `.env.example`, completing the copy-and-fill workflow described in the PR. The change is minimal, correctly placed, and transparent when `.env` is absent.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, correctly implemented change with no logic regressions.

No P0 or P1 findings. The side-effect import is placed before all other imports so env vars are available to every downstream module, dotenv is silent on a missing file, and the `.env.example` template is now complete. The previously flagged P2 concern (missing `JADE_SESSION_COOKIE` placeholder) has been addressed in this PR.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/index.ts | Adds `import "dotenv/config"` as the very first line — correct placement to populate `process.env` before any subsequent module (including `config.ts`) is evaluated. |
| .env.example | Adds commented-out `JADE_SESSION_COOKIE` placeholder with a usage note, completing the template for the copy-and-fill workflow. |
| package.json | Adds `dotenv ^17.4.2` to runtime dependencies — appropriate as a production dependency since the entrypoint loads it unconditionally. |
| package-lock.json | Lock file updated to pin `dotenv@17.4.2`; integrity hash and metadata look correct. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[node dist/index.js] --> B["import dotenv/config (side-effect)"]
    B --> C{.env file present?}
    C -- Yes --> D[Parse key-value pairs into process.env]
    C -- No --> E[Silent no-op]
    D --> F[Import config.ts]
    E --> F
    F --> G[Read configuration with defaults]
    G --> H[Register MCP tools]
    H --> I[Start stdio or HTTP transport]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.env.example`, line 27 ([link](https://github.com/russellbrenner/auslaw-mcp/blob/fae21f47a0784522d00b6a4b5d4e324a7596c0c6/.env.example#L27)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`JADE_SESSION_COOKIE` missing from `.env.example` template**

   The PR's stated purpose is to make `.env.example` usable by doing `cp .env.example .env`, fill in values. However, `JADE_SESSION_COOKIE` — the primary secret the dotenv loader is meant to help contributors supply — has no placeholder entry in the template. A contributor following the copy-and-fill workflow won't know to add this variable unless they separately consult `AGENTS.md`. Adding even a commented-out placeholder (e.g. `# JADE_SESSION_COOKIE=IID=...;alcsessionid=...;cf_clearance=...`) would complete the workflow the PR describes.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .env.example
   Line: 27

   Comment:
   **`JADE_SESSION_COOKIE` missing from `.env.example` template**

   The PR's stated purpose is to make `.env.example` usable by doing `cp .env.example .env`, fill in values. However, `JADE_SESSION_COOKIE` — the primary secret the dotenv loader is meant to help contributors supply — has no placeholder entry in the template. A contributor following the copy-and-fill workflow won't know to add this variable unless they separately consult `AGENTS.md`. Adding even a commented-out placeholder (e.g. `# JADE_SESSION_COOKIE=IID=...;alcsessionid=...;cf_clearance=...`) would complete the workflow the PR describes.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.env.example%0ALine%3A%2027%0A%0AComment%3A%0A**%60JADE_SESSION_COOKIE%60%20missing%20from%20%60.env.example%60%20template**%0A%0AThe%20PR's%20stated%20purpose%20is%20to%20make%20%60.env.example%60%20usable%20by%20doing%20%60cp%20.env.example%20.env%60%2C%20fill%20in%20values.%20However%2C%20%60JADE_SESSION_COOKIE%60%20%E2%80%94%20the%20primary%20secret%20the%20dotenv%20loader%20is%20meant%20to%20help%20contributors%20supply%20%E2%80%94%20has%20no%20placeholder%20entry%20in%20the%20template.%20A%20contributor%20following%20the%20copy-and-fill%20workflow%20won't%20know%20to%20add%20this%20variable%20unless%20they%20separately%20consult%20%60AGENTS.md%60.%20Adding%20even%20a%20commented-out%20placeholder%20%28e.g.%20%60%23%20JADE_SESSION_COOKIE%3DIID%3D...%3Balcsessionid%3D...%3Bcf_clearance%3D...%60%29%20would%20complete%20the%20workflow%20the%20PR%20describes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=russellbrenner%2Fauslaw-mcp&pr=84&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["docs(env): add JADE\_SESSION\_COOKIE place..."](https://github.com/russellbrenner/auslaw-mcp/commit/35befbff6bea9144fb5920a3cd1d0d464a815df7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30543227)</sub>

<!-- /greptile_comment -->