### PR TITLE
fix(test): use path.join in source-store path assertion

### DIFF
--- a/src/test/unit/source-store.test.ts
+++ b/src/test/unit/source-store.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import path from "node:path";
 
 const mockFs = vi.hoisted(() => ({
   mkdir: vi.fn(),
@@ -165,7 +166,7 @@ describe("storeSource", () => {
 
   it("returns path under sourcesDir", async () => {
     const result = await storeSource("mabo1992", TEST_URL, null, SOURCES_DIR);
-    expect(result.path).toBe(`${SOURCES_DIR}/mabo1992.md`);
+    expect(result.path).toBe(path.join(SOURCES_DIR, "mabo1992.md"));
   });
 
   it("captures etag from HEAD response", async () => {


### PR DESCRIPTION
## Summary

- `src/test/unit/source-store.test.ts:168` asserted `${SOURCES_DIR}/mabo1992.md` literally, while the implementation in `src/services/source-store.ts:93` builds the path with `path.join(...)`.
- On Windows `path.join` returns `\test\project\sources\mabo1992.md`, which doesn't equal the forward-slash literal — so the test failed on Windows but passed on POSIX (where `path.join` happens to use `/`).
- Switches the assertion to `path.join(SOURCES_DIR, "mabo1992.md")`, which mirrors the production call and is platform-agnostic.

Fixes #85.

## Test plan

- [x] `npx vitest run src/test/unit/source-store.test.ts` — 14/14 pass on Windows
- [x] `npx vitest run src/test/unit/` — 312/312 pass on Windows (was 311/312 before this change)
- POSIX behaviour unchanged (`path.join` returns the same string the test previously asserted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

[Greptile](https://greptile.com)
---

<h3>Greptile Summary</h3>

This PR fixes a Windows-only test failure in `source-store.test.ts` where the assertion used a hard-coded forward-slash path literal (`${SOURCES_DIR}/mabo1992.md`) while the production code at `source-store.ts:93` constructs the path with `path.join`. The fix aligns the assertion with the implementation by importing `node:path` and switching the assertion to `path.join(SOURCES_DIR, "mabo1992.md")`, making it platform-agnostic.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a minimal, correct fix that aligns a test assertion with the production code path construction.

Single-line test change with no logic impact. The fix directly mirrors the production path.join call, resolves a real cross-platform failure, and leaves all other tests unaffected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/test/unit/source-store.test.ts | Adds `path` import and replaces a hard-coded forward-slash path string with `path.join(SOURCES_DIR, "mabo1992.md")` to mirror the production call and fix Windows test failure. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["storeSource(citeKey, url, cached, sourcesDir)"] --> B["path.join(sourcesDir, citeKey + '.md')"]
    B --> C["filePath"]
    C --> D["Return StoreSourceResult { path: filePath, ... }"]

    E["Test: result.path assertion"] -->|"Before (POSIX only)"| F["'${SOURCES_DIR}/mabo1992.md'"]
    E -->|"After (platform-agnostic)"| G["path.join(SOURCES_DIR, 'mabo1992.md')"]
    G --> H["Matches production path on Windows & POSIX"]
    F --> I["Fails on Windows (backslash vs forward-slash)"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(test): use path.join in source-store..."](https://github.com/russellbrenner/auslaw-mcp/commit/6d3d88e2e3b0597dead17518e7272218583c380c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30543470)</sub>

<!-- /greptile_comment -->