### PR TITLE
fix: refresh jade.io GWT constants for 2026-05-02 deploy

### DIFF
--- a/src/services/jade-gwt.ts
+++ b/src/services/jade-gwt.ts
@@ -67,16 +67,16 @@ export const JADE_MODULE_BASE = "https://jade.io/au.com.barnet.jade.JadeClient/"
  * This may change when jade.io redeploys the GWT app.
  * If content fetching returns an exception response, this hash may need refreshing
  * by inspecting the X-GWT-Permutation header in a fresh browser session.
- * Last verified: 2026-03-03.
+ * Last verified: 2026-05-02.
  */
-export const JADE_STRONG_NAME = "B4F37C2BEC5AB097C4C8696FD843C56D";
+export const JADE_STRONG_NAME = "78A4E1BF92432B956B45BFCCAAD8EA7F";
 
 /**
  * GWT-RPC strong name (type hash) for ArticleViewRemoteService.
  * This service handles article content loading via the avd2Request method.
- * Discovered via SPA navigation interception (2026-03-02). Last verified: 2026-03-03.
+ * Discovered via SPA navigation interception (2026-03-02). Last verified: 2026-05-02.
  */
-export const AVD2_STRONG_NAME = "159521E79F7322FD92335ED73B4403F9";
+export const AVD2_STRONG_NAME = "540FEEFE1755510EEA65022BF9AEE249";
 
 /**
  * GWT permutation identifier for the Chrome/macOS compiled JS bundle.
@@ -91,9 +91,9 @@ export const JADE_PERMUTATION = "FEBDA911A95AD2DF02425A9C60379101";
  * GWT-RPC strong name (type hash) for LeftoverRemoteService.
  * This service handles citation-context searches ("who cites this article")
  * and citation data retrieval. NOT used for freetext case search.
- * Discovered from HAR analysis (2026-03-03).
+ * Discovered from HAR analysis (2026-03-03). Last verified: 2026-05-02.
  */
-export const LEFTOVER_STRONG_NAME = "CCB23EABE2EF1A4CA63F2E243C979468";
+export const LEFTOVER_STRONG_NAME = "1D24CC41B607715BFC2FAE9A28012C5F";
 
 /**
  * Encodes a non-negative integer using GWT's custom base-64 charset.
@@ -242,13 +242,13 @@ export function buildAvd2Request(articleId: number): string {
   return (
     `7|0|10|${JADE_MODULE_BASE}|${AVD2_STRONG_NAME}|` +
     `au.com.barnet.jade.cs.remote.ArticleViewRemoteService|avd2Request|` +
-    `au.com.barnet.jade.cs.csobjects.avd.Avd2Request/2068227305|` +
+    `au.com.barnet.jade.cs.csobjects.avd.Avd2Request/2858816011|` +
     `au.com.barnet.jade.cs.persistent.Jrl/728826604|` +
     `au.com.barnet.jade.cs.persistent.Article|` +
     `java.util.ArrayList/4159755760|` +
     `au.com.barnet.jade.cs.csobjects.avd.PhraseFrequencyParams/1915696367|` +
     `cc.alcina.framework.common.client.util.IntPair/1982199244|` +
-    `1|2|3|4|1|5|5|A|A|0|6|${encodedId}|A|0|A|A|7|0|0|0|8|0|0|9|0|10|3|500|A|8|0|`
+    `1|2|3|4|1|5|5|A|A|0|6|${encodedId}|A|0|A|A|7|0|0|0|8|0|0|9|0|10|3|500|A|8|0|8|0|`
   );
 }
 
@@ -874,7 +874,7 @@ export function buildCitatorSearchRequest(citableId: number): string {
     `cc.alcina.framework.common.client.logic.FilterCombinator/3213752301|` +
     `au.com.barnet.jade.cs.trans.othersearch.citation.CitableAndSectionsCriterion/4126754736|` +
     `au.com.barnet.jade.cs.trans.othersearch.citation.CitableCriterion/1545253367|` +
-    `cc.alcina.framework.gwt.client.objecttree.search.StandardSearchOperator/2480038826|` +
+    `cc.alcina.framework.gwt.client.objecttree.search.StandardSearchOperator/2244035871|` +
     `java.util.ArrayList/4159755760|` +
     `au.com.barnet.jade.cs.trans.searchcriteria.JTextCriteriaGroup/1895870655|` +
     `text (in the citing case)|` +


### PR DESCRIPTION
## Summary

jade.io redeployed since 2026-03-03; the existing constants in `src/services/jade-gwt.ts` no longer match the server, and content-fetch / search calls return empty bodies that the client surfaces as \`Unexpected GWT-RPC response format (expected //OK prefix)\`.

This refreshes the values that are actually validated server-side, captured from a live logged-in browser session and verified individually via differential testing.

## What changed

| Constant / structure | Old | New | Service |
|---|---|---|---|
| \`JADE_STRONG_NAME\` | \`B4F37C2B…\` | \`78A4E1BF…\` | JadeRemoteService — proposeCitables / searchArticles |
| \`AVD2_STRONG_NAME\` | \`159521E7…\` | \`540FEEFE…\` | ArticleViewRemoteService — avd2Request |
| \`Avd2Request\` class hash (in \`buildAvd2Request\`) | \`/2068227305\` | \`/2858816011\` | DTO serialisation fingerprint |
| \`buildAvd2Request\` trailing fields | \`…\|A\|8\|0\|\` | \`…\|A\|8\|0\|8\|0\|\` | request schema gained one extra field |
| \`LEFTOVER_STRONG_NAME\` | \`CCB23EAB…\` | \`1D24CC41…\` | LeftoverRemoteService — citator search (\`search_citing_cases\`) |
| \`StandardSearchOperator\` class hash (in \`buildCitatorSearchRequest\`) | \`/2480038826\` | \`/2244035871\` | DTO serialisation fingerprint |

\`Last verified\` comments updated to 2026-05-02 across all three constants.

## Why these and not \`JADE_PERMUTATION\`

Differential test, same endpoint and body, only varying \`X-GWT-Permutation\`:

\`\`\`
NEW perm B1DF7BC3...   status: 200 len: 68533 OK: yes
OLD perm FEBDA911...   status: 200 len: 68533 OK: yes
GARBAGE perm AAAA...   status: 200 len: 68533 OK: yes
EMPTY perm             status: 200 len: 68533 OK: yes
\`\`\`

The header is not validated server-side. \`JADE_PERMUTATION\` is decorative and left untouched to keep the diff minimal.

## Why each change is a real gate

Differential approach for each path, varying one value at a time, raw \`https\` POST, fresh cookies, Chrome UA.

**ArticleViewRemoteService (avd2Request):**
\`\`\`
baseline NEW everything       len: 68533  OK: yes
OLD strong name only          len: 0      OK: no
GARBAGE strong name           len: 0      OK: no
OLD class hash only           len: 0      OK: no
GARBAGE class hash            len: 0      OK: no
NO trailing 8|0| (old tail)   len: 0      OK: no
EXTRA trailing 8|0|           len: 68533  OK: yes  (server tolerates extras)
\`\`\`

**JadeRemoteService (proposeCitables):**
\`\`\`
NEW JADE_STRONG_NAME          len: 75141  OK: yes
OLD JADE_STRONG_NAME          len: 0      OK: no
GARBAGE strong name           len: 0      OK: no
\`\`\`

**LeftoverRemoteService (citator search):**
\`\`\`
baseline (live captured body)              len: 166181  OK: yes
OLD LEFTOVER_STRONG_NAME swapped in        len: 0       OK: no
OLD StandardSearchOperator hash            len: 0       OK: no
NEW strong name + OLD field order          len: 166181  OK: yes  (field order non-gating)
\`\`\`

So each strong name + class hash + trailing-field-count is a server-validated gate. Field ordering for \`IgnoreShortCitations\` / \`IgnoreSelfCitations\` is non-gating (server accepts both) — kept the project's existing order.

## Test plan

- [x] \`npm run build\` clean
- [x] Replay raw \`https\` POST against \`jade.io/jadeService.do\` with the new \`avd2Request\` body returns \`//OK[…]\` 68KB content
- [x] Replay raw \`https\` POST with the new \`proposeCitables\` body returns \`//OK[…]\` 75KB
- [x] Replay raw \`https\` POST with the new \`LeftoverRemoteService.search\` body returns \`//OK[…]\` 166KB
- [x] In-process \`fetch_document_text\` against jade.io article 67401 (Kosciusko Thredbo v Commissioner of Taxation [1987] HCA 64) returns full judgment text
- [x] In-process \`searchJade(\"Mabo v Queensland\")\` returns valid results
- [x] Differential tests above isolate which fields are gates
- [x] Existing unit tests still pass on this branch (1 pre-existing Windows path-separator failure in \`source-store.test.ts:168\` unrelated to this PR; tracked in #85, fix in #86)

## Notes

- Independent of #82 (npx-launch wiring).
- Not directly tested but inferred from working: the \`proposeCitables\` class hashes (\`QuickSearchFlags/2740681188\`, \`QuickSearchFlagsDesktop/2291862948\`, \`HashSet/3273092938\`, \`CitableType/1576180844\`) appear unchanged in this redeploy — they're left at the existing project values and \`searchJade\` works with them. If a future redeploy breaks search, those would be the next places to refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)