### PR TITLE
feat: load .env on startup via dotenv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ AUSTLII_TIMEOUT=60000
 JADE_BASE_URL=https://jade.io
 JADE_USER_AGENT=auslaw-mcp/0.1.0 (legal research tool)
 JADE_TIMEOUT=15000
+# Required for jade.io authenticated features (search, full-text fetch).
+# Copy your session cookie from browser DevTools → Application → Cookies → jade.io.
+# Format: IID=...; alcsessionid=...; cf_clearance=...
+# JADE_SESSION_COOKIE=IID=...;alcsessionid=...;cf_clearance=...
 
 # OCR Configuration
 OCR_LANGUAGE=eng

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.15.2",
         "cheerio": "^1.1.2",
+        "dotenv": "^17.4.2",
         "file-type": "^21.3.0",
         "pdf-parse": "^2.4.5",
         "tmp": "^0.2.5",
@@ -2729,6 +2730,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.15.2",
     "cheerio": "^1.1.2",
+    "dotenv": "^17.4.2",
     "file-type": "^21.3.0",
     "pdf-parse": "^2.4.5",
     "tmp": "^0.2.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import "dotenv/config";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";


### PR DESCRIPTION
Applies the changes from #84 (which had a package-lock.json merge conflict after #82 was merged).

- Adds `dotenv ^17.4.2` runtime dependency
- Inserts `import "dotenv/config"` after the shebang in `src/index.ts` so `.env` is loaded before `config.ts` reads env vars
- Adds `JADE_SESSION_COOKIE` placeholder to `.env.example` to complete the copy-and-fill workflow

Closes #84

https://claude.ai/code/session_01Q6KyQJcwEDwDQq7SrX7Cna

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6KyQJcwEDwDQq7SrX7Cna)_

<!-- greptile_comment -->

[Greptile](https://greptile.com)
---

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `dotenv` as a runtime dependency and loads it via `import "dotenv/config"` at the top of `src/index.ts`, ensuring `.env` is parsed before any other module initialises. It also adds a `JADE_SESSION_COOKIE` placeholder to `.env.example` to complete the copy-and-fill workflow for local development.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — only a minor formatting inconsistency in `.env.example`.

All findings are P2. The implementation is correct: dotenv is placed in `dependencies` (not `devDependencies`), the ESM side-effect import is positioned correctly after the shebang, and `.env` is already in `.gitignore`.

`.env.example` — minor cookie separator inconsistency between the format comment and the example value.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/index.ts | Adds `import "dotenv/config"` immediately after the shebang — correct ESM side-effect placement ensuring `.env` is loaded before any other module initialises. |
| .env.example | Adds commented `JADE_SESSION_COOKIE` placeholder with helpful inline documentation; minor inconsistency between the described cookie separator format and the example value. |
| package.json | Adds `dotenv ^17.4.2` as a runtime dependency — correctly placed in `dependencies` (not `devDependencies`) since it is needed at runtime. |
| package-lock.json | Lock file updated to resolve `dotenv@17.4.2` with correct integrity hash; no conflicts. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Node.js starts src/index.ts"] --> B["import dotenv/config"]
    B --> C["dotenv reads configuration from disk"]
    C --> D["process.env populated"]
    D --> E["config.ts reads settings"]
    E --> F["MCP server registers tools and starts transport"]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.env.example%3A16-17%0A**Inconsistent%20cookie%20separator%20formatting**%0A%0AThe%20%60Format%3A%60%20comment%20uses%20%60%3B%20%60%20%28semicolon%20%2B%20space%29%20as%20a%20separator%2C%20matching%20how%20browsers%20format%20cookie%20strings%2C%20but%20the%20example%20value%20uses%20%60%3B%60%20without%20a%20space.%20Users%20copying%20the%20example%20literally%20would%20produce%20a%20subtly%20different%20string%20than%20the%20format%20description%20implies.%0A%0AConsider%20aligning%20the%20example%20with%20the%20described%20format%2C%20or%20adding%20a%20note%20that%20both%20forms%20are%20accepted.%0A%0A&repo=russellbrenner%2Fauslaw-mcp&pr=88&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.env.example:16-17
**Inconsistent cookie separator formatting**

The `Format:` comment uses `; ` (semicolon + space) as a separator, matching how browsers format cookie strings, but the example value uses `;` without a space. Users copying the example literally would produce a subtly different string than the format description implies.

Consider aligning the example with the described format, or adding a note that both forms are accepted.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: load .env on startup via dotenv (#..."](https://github.com/russellbrenner/auslaw-mcp/commit/b99f220a192465c3fca44aa6a32416821c72075c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30548618)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->