### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/src/services/fetcher.ts
+++ b/src/services/fetcher.ts
@@ -139,8 +139,15 @@ function extractTextFromHtml(html: string, url?: string): string {
   const $ = cheerio.load(html);
 
   // Check if this is jade.io
-  if (url && url.includes("jade.io")) {
-    return extractTextFromJadeHtml(html);
+  if (url) {
+    try {
+      const hostname = new URL(url).hostname.toLowerCase();
+      if (hostname === "jade.io" || hostname.endsWith(".jade.io")) {
+        return extractTextFromJadeHtml(html);
+      }
+    } catch {
+      // If URL parsing fails, fall through to generic extraction.
+    }
   }
 
   // Remove script and style elements

--- a/src/test/unit/fetcher.test.ts
+++ b/src/test/unit/fetcher.test.ts
@@ -125,6 +125,37 @@ describe("fetchDocumentText", () => {
     }
   });
 
+  it("routes www.jade.io subdomain through jade GWT-RPC (hostname.endsWith check)", async () => {
+    mockConfig.jade.sessionCookie = "IID=abc; alcsessionid=xyz";
+
+    const jadeHtml = "<div class='judgment-text'><p>[1] Subdomain judgment text.</p></div>";
+    vi.mocked(axios.post).mockResolvedValueOnce({
+      data: `//OK[0,-2,0,["Type/123","${jadeHtml}"],4,7]`,
+      status: 200,
+      headers: {},
+    });
+
+    const result = await fetchDocumentText("https://www.jade.io/article/67401");
+    expect(result.text).toContain("Subdomain judgment text");
+    expect(result.sourceUrl).toBe("https://www.jade.io/article/67401");
+  });
+
+  it("uses generic extraction for AustLII URL that contains 'jade.io' in query string", async () => {
+    // Regression: old url.includes("jade.io") would misroute this to jade extraction.
+    // assertFetchableUrl permits www.austlii.edu.au; hostname != jade.io so generic path is used.
+    const html = "<html><body><p>AustLII generic content</p></body></html>";
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: Buffer.from(html),
+      headers: { "content-type": "text/html" },
+      status: 200,
+    });
+
+    const result = await fetchDocumentText(
+      "https://www.austlii.edu.au/cgi-bin/viewdoc?ref=jade.io",
+    );
+    expect(result.text).toContain("AustLII generic content");
+  });
+
   it("extracts paragraph blocks from AustLII HTML with [N] markers", async () => {
     const html = `<html><body>
       <p>[1] First paragraph text here.</p>


### PR DESCRIPTION
Potential fix for [https://github.com/russellbrenner/auslaw-mcp/security/code-scanning/4](https://github.com/russellbrenner/auslaw-mcp/security/code-scanning/4)

The correct fix is to parse the URL and check the hostname explicitly, rather than checking whether a substring appears anywhere in the URL string.

Best targeted fix (without changing intended functionality): in `src/services/fetcher.ts` inside `extractTextFromHtml`, replace the `url.includes("jade.io")` condition with hostname-based matching via `new URL(url).hostname`, allowing `jade.io` and its subdomains (e.g., `www.jade.io`). Wrap parsing in a `try/catch` so invalid/relative URLs do not throw and simply fall back to generic extraction.

No new imports or dependencies are required; `URL` is globally available in Node.js.

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- greptile_comment -->

[Greptile](https://greptile.com)
---

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a URL substring sanitisation vulnerability (CodeQL alert #4) in `src/services/fetcher.ts` where `url.includes("jade.io")` inside `extractTextFromHtml` could be bypassed by any URL carrying `jade.io` as a query parameter or path segment (e.g. `https://evil.com/?q=jade.io`). The fix replaces the substring check with a proper `new URL(url).hostname` comparison, wrapped in a `try/catch` for malformed URLs, and adds two targeted regression tests.
</details>

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge; it is a narrow, well-tested security fix with no regressions.

No P0 or P1 issues found. The hostname-based check is correct, consistent with the existing `isJadeUrl` implementation, and the `assertFetchableUrl` allowlist provides an additional layer of defence. Both new tests pass the logic checks.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/services/fetcher.ts | Replaces substring URL check with hostname-based matching and a try/catch; fix is correct and consistent with the existing `isJadeUrl` implementation in jade.ts. |
| src/test/unit/fetcher.test.ts | Adds two tests: one for www.jade.io subdomain routing and one regression test for AustLII URLs containing 'jade.io' in a query string; both cover the key code paths introduced by the fix. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["fetchDocumentText(url)"] --> B["assertFetchableUrl(url)\n(strict allowlist)"]
    B --> C{"isJadeUrl(url)\nhostname-based"}
    C -- "jade.io / *.jade.io" --> D["GWT-RPC fetch\nfetchJadeArticleContent()"]
    D --> E["extractTextFromHtml(html, url)"]
    C -- "austlii etc." --> F["axios.get fetch"]
    F --> E
    E --> G{"new URL(url).hostname\n== jade.io or\n.endsWith('.jade.io')?"}
    G -- "yes" --> H["extractTextFromJadeHtml(html)"]
    G -- "no" --> I["Generic HTML extraction"]
    G -- "URL parse throws" --> I
    H --> J["Jade-specific selectors\n.judgment-text etc."]
    J -- "found" --> K["return text"]
    J -- "not found" --> I
    I --> K
```

<sub>Reviews (2): Last reviewed commit: ["test: add hostname-matching coverage for..."](https://github.com/russellbrenner/auslaw-mcp/commit/4428cac887ca716d27ac82ac97d2477839de6b84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30551659)</sub>

<!-- /greptile_comment -->