### PR TITLE
fix: skip redundant HEAD in check_source_freshness re-download path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -860,7 +860,7 @@ function createMcpServer(): McpServer {
       if (!freshness.fresh) {
         // Remote is newer — re-download
         try {
-          const storeResult = await storeSource(citeKey, entry.url, entry, config.sources.dir);
+          const storeResult = await storeSource(citeKey, entry.url, null, config.sources.dir);
           const relPath = path.relative(config.cache.dir, storeResult.path);
           await updateSourceFields(config.cache.dir, citeKey, {
             sourceFile: relPath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -860,7 +860,12 @@ function createMcpServer(): McpServer {
       if (!freshness.fresh) {
         // Remote is newer — re-download
         try {
-          const storeResult = await storeSource(citeKey, entry.url, null, config.sources.dir);
+          const storeResult = await storeSource(
+            citeKey,
+            entry.url,
+            { contentHash: entry.contentHash },
+            config.sources.dir,
+          );
           const relPath = path.relative(config.cache.dir, storeResult.path);
           await updateSourceFields(config.cache.dir, citeKey, {
             sourceFile: relPath,


### PR DESCRIPTION
## Summary

- When `checkSourceFreshness` returns `fresh: false`, `storeSource` was being called with the cached `entry` (which has `sourceEtag`/`sourceLastModified` set), causing it to immediately issue a redundant conditional HEAD request before re-fetching the full document
- The caller already knows the document is stale at this point, so there is no value in the extra round-trip
- Fix: pass `null` for `cached` so `storeSource` skips the freshness pre-check and goes straight to the GET

## Test plan

- [x] `npm run build` — zero TypeScript errors
- [x] `npx vitest run src/test/unit/` — all tests pass

https://claude.ai/code/session_01Q6KyQJcwEDwDQq7SrX7Cna

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6KyQJcwEDwDQq7SrX7Cna)_

<!-- greptile_comment -->

[Greptile](https://greptile.com)
---

<details><summary><h3>Greptile Summary</h3></summary>

This PR addresses a redundant conditional HEAD request in the `check_source_freshness` re-download path. When `checkSourceFreshness` returned `fresh: false`, `storeSource` was being called with the full `entry` (including `sourceEtag`/`sourceLastModified`), causing it to immediately issue another HEAD before re-fetching — a round-trip that adds no value since staleness is already confirmed. The fix passes `{ contentHash: entry.contentHash }` so `storeSource` skips the freshness pre-check whilst still preserving the content-hash comparison that gates actual disk writes.
</details>

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — the fix is minimal, targeted, and correctly preserves content-hash diffing whilst eliminating the redundant network round-trip.

Single-line change with no P0 or P1 findings. The chosen approach (`{ contentHash: entry.contentHash }`) directly addresses the previous review comment about losing hash comparison when passing `null`, and the logic in `source-store.ts` confirms it behaves as intended.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/index.ts | Passes `{ contentHash: entry.contentHash }` instead of the full `entry` to `storeSource`, correctly skipping the redundant HEAD whilst preserving content-hash diffing — clean and precise fix. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as check_source_freshness handler
    participant CSF as checkSourceFreshness
    participant SS as storeSource

    Caller->>CSF: HEAD (If-None-Match / If-Modified-Since)
    CSF-->>Caller: fresh: false (HTTP 200)

    Note over Caller,SS: Before fix — entry passed with sourceEtag/sourceLastModified
    Caller->>SS: storeSource(..., entry, ...)
    SS->>CSF: HEAD (redundant — staleness already known)
    CSF-->>SS: fresh: false
    SS->>SS: GET full document
    SS-->>Caller: StoreSourceResult

    Note over Caller,SS: After fix — only contentHash passed
    Caller->>SS: storeSource(..., { contentHash }, ...)
    SS->>SS: GET full document (no pre-check HEAD)
    SS->>SS: compare SHA-256 vs contentHash
    SS-->>Caller: StoreSourceResult
```

<sub>Reviews (2): Last reviewed commit: ["fix: preserve contentHash when skipping ..."](https://github.com/russellbrenner/auslaw-mcp/commit/29834f2a8b96db6144050a90520331b33134ed10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30551791)</sub>

<!-- /greptile_comment -->