### PR TITLE
refactor: replace PINPOINT_PATTERNS magic-index cascade with structured loop

### DIFF
--- a/src/services/citation.ts
+++ b/src/services/citation.ts
@@ -96,20 +96,14 @@ export function formatShortForm(input: ShortFormInput): string {
   }
 }
 
-// Broad pinpoint patterns for parseCitation
-// Order matters — more specific patterns first
-const PINPOINT_PATTERNS = [
-  // Paragraph range: at [64] to [66]
-  /\bat\s+\[(\d+)\]\s+to\s+\[(\d+)\]/,
-  // Page range: at 401 to 407
-  /\bat\s+(\d+)\s+to\s+(\d+)(?!\])/,
-  // Paragraph: at [20]
-  /\bat\s+\[(\d+)\]/,
-  // Page number: at 401
-  /\bat\s+(\d+)(?!\])/,
-  // Legislation: at s 5(2)(a) / reg 12 / sch 1
-  /\bat\s+((?:ss?|reg|regs?|sch)\s+\S[^,;]*)/,
-] as const;
+// Broad pinpoint patterns for parseCitation — most specific first
+const PINPOINT_PATTERNS: ReadonlyArray<{ re: RegExp; extract: (m: RegExpMatchArray) => string }> = [
+  { re: /\bat\s+\[(\d+)\]\s+to\s+\[(\d+)\]/, extract: (m) => `[${m[1]!}] to [${m[2]!}]` },
+  { re: /\bat\s+(\d+)\s+to\s+(\d+)(?!\])/, extract: (m) => `${m[1]!} to ${m[2]!}` },
+  { re: /\bat\s+\[(\d+)\]/, extract: (m) => `[${m[1]!}]` },
+  { re: /\bat\s+(\d+)(?!\])/, extract: (m) => m[1]! },
+  { re: /\bat\s+((?:ss?|reg|regs?|sch)\s+\S[^,;]*)/, extract: (m) => m[1]!.trim() },
+];
 
 export function parseCitation(text: string): ParsedCitation | null {
   const neutralMatch = text.match(NEUTRAL_CITATION_PATTERN);
@@ -129,30 +123,13 @@ export function parseCitation(text: string): ParsedCitation | null {
     return null;
   }
 
-  // Try each pinpoint pattern in order
+  // Try each pinpoint pattern in priority order
   let pinpoint: string | undefined;
-  const paraRangeMatch = text.match(PINPOINT_PATTERNS[0]);
-  if (paraRangeMatch?.[1] && paraRangeMatch[2]) {
-    pinpoint = `[${paraRangeMatch[1]}] to [${paraRangeMatch[2]}]`;
-  } else {
-    const pageRangeMatch = text.match(PINPOINT_PATTERNS[1]);
-    if (pageRangeMatch?.[1] && pageRangeMatch[2]) {
-      pinpoint = `${pageRangeMatch[1]} to ${pageRangeMatch[2]}`;
-    } else {
-      const paraMatch = text.match(PINPOINT_PATTERNS[2]);
-      if (paraMatch?.[1]) {
-        pinpoint = `[${paraMatch[1]}]`;
-      } else {
-        const pageMatch = text.match(PINPOINT_PATTERNS[3]);
-        if (pageMatch?.[1]) {
-          pinpoint = pageMatch[1];
-        } else {
-          const legisMatch = text.match(PINPOINT_PATTERNS[4]);
-          if (legisMatch?.[1]) {
-            pinpoint = legisMatch[1].trim();
-          }
-        }
-      }
+  for (const { re, extract } of PINPOINT_PATTERNS) {
+    const m = text.match(re);
+    if (m) {
+      pinpoint = extract(m);
+      break;
     }
   }
 


### PR DESCRIPTION
## Summary

- `PINPOINT_PATTERNS` was a plain regex array accessed by positional index (`[0]`…`[4]`) in a nested `if/else` cascade — reordering or inserting a pattern required updating every call-site index
- Each entry now carries its own `extract` callback, and the call site is a single `for...of` loop with a `break` on first match
- Behaviour is identical; no logic changed

## Test plan

- [x] `npm run build` — zero TypeScript errors
- [x] `npx vitest run src/test/unit/citation.test.ts` — 51 passed, 1 skipped

https://claude.ai/code/session_01Q6KyQJcwEDwDQq7SrX7Cna

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6KyQJcwEDwDQq7SrX7Cna)_

<!-- greptile_comment -->

[Greptile](https://greptile.com)
---

<details><summary><h3>Greptile Summary</h3></summary>

This PR refactors `PINPOINT_PATTERNS` in `src/services/citation.ts` from a plain `RegExp[]` accessed by positional index within a deeply-nested `if/else` cascade into a `ReadonlyArray` of `{ re, extract }` objects iterated with a single `for...of` loop. Behaviour is unchanged — pattern priority order is preserved, and the `extract` callbacks reproduce exactly the string-building logic from the old cascade.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure structural refactoring with no logic changes.

All five extract callbacks reproduce the exact string-building logic from the old cascade, pattern priority order is preserved, and the non-null assertions on capture groups are sound given that every capture group in each regex is mandatory (non-optional). No behaviour change is introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/services/citation.ts | Refactored PINPOINT_PATTERNS array from positional RegExp[] to ReadonlyArray of {re, extract} objects, and replaced the nested if/else cascade with a for...of loop — logic is identical, no issues found. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[parseCitation called] --> B{Neutral or reported\ncitation found?}
    B -- No --> C[return null]
    B -- Yes --> D[Iterate PINPOINT_PATTERNS\nfor...of loop]
    D --> E{text.match re ?}
    E -- No match --> F{More patterns?}
    F -- Yes --> D
    F -- No --> G[pinpoint = undefined]
    E -- Match --> H[pinpoint = extract m\nbreak]
    G --> I[return ParsedCitation]
    H --> I
```

<sub>Reviews (1): Last reviewed commit: ["refactor: replace PINPOINT\_PATTERNS magi..."](https://github.com/russellbrenner/auslaw-mcp/commit/bb8681fa3510756fcc9aeda028a7f6fabccb0d5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30551793)</sub>

<!-- /greptile_comment -->