### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint and Format Check


### PR DESCRIPTION
Potential fix for [https://github.com/russellbrenner/jurisd/security/code-scanning/3](https://github.com/russellbrenner/jurisd/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root (top-level), so all jobs inherit least-privilege token access unless overridden.  
For this workflow, the best minimal fix without changing behavior is:

- In `.github/workflows/main.yml`, insert:
  - `permissions:`
  - `  contents: read`
- Place it after the `on:` triggers block and before `jobs:`.

Why this is best:
- One centralized change covers `lint`, `test`, and `security` consistently.
- It aligns with CodeQL’s suggested minimum.
- It preserves current functionality because these jobs only need repository read access for checkout and build/test/audit tasks.

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
