### PR TITLE
chore(fetcher): remove Tesseract OCR fallback for scanned PDFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and documentation. Configuration env vars (`AUSLAW_*`) and the `.auslaw/` cache directory
   are unchanged.
 
+### Removed
+
+- Removed the Tesseract OCR fallback for scanned PDFs in `fetch_document_text` (`pdf-parse` digital-text extraction retained).
+
 ### Documentation
 
 - Day-0 front-door docs overhaul for public release: rewrote `README.md` around the

--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@
 server:
   name: jurisd
   version: 0.1.0
-  description: Australian legislation and case law searcher with OCR-aware document retrieval.
+  description: Australian legislation and case law searcher with document retrieval.
 
 austlii:
   # Base URL for AustLII search
@@ -29,16 +29,6 @@ jade:
 
   # Request timeout in milliseconds
   timeout: ${JADE_TIMEOUT:-15000}
-
-ocr:
-  # OCR language (default: English)
-  language: ${OCR_LANGUAGE:-eng}
-
-  # OCR Engine Mode (0-3, default 1 for LSTM neural network)
-  oem: ${OCR_OEM:-1}
-
-  # Page Segmentation Mode (default 3 for automatic)
-  psm: ${OCR_PSM:-3}
 
 defaults:
   # Default number of search results

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -13,11 +13,6 @@ data:
   AUSTLII_USER_AGENT: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
   AUSTLII_TIMEOUT: "60000"
 
-  # OCR Configuration
-  OCR_LANGUAGE: "eng"
-  OCR_OEM: "1"
-  OCR_PSM: "3"
-
   # Default Settings
   DEFAULT_SEARCH_LIMIT: "10"
   MAX_SEARCH_LIMIT: "50"
@@ -37,18 +32,13 @@ data:
     server:
       name: jurisd
       version: 0.1.0
-      description: Australian legislation and case law searcher with OCR-aware document retrieval.
+      description: Australian legislation and case law searcher with document retrieval.
 
     austlii:
       searchBase: ${AUSTLII_SEARCH_BASE:-https://www.austlii.edu.au/cgi-bin/sinosrch.cgi}
       referer: ${AUSTLII_REFERER:-https://www.austlii.edu.au/forms/search1.html}
       userAgent: ${AUSTLII_USER_AGENT:-Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36}
       timeout: ${AUSTLII_TIMEOUT:-60000}
-
-    ocr:
-      language: ${OCR_LANGUAGE:-eng}
-      oem: ${OCR_OEM:-1}
-      psm: ${OCR_PSM:-3}
 
     defaults:
       searchLimit: ${DEFAULT_SEARCH_LIMIT:-10}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jurisd",
   "version": "0.1.0",
-  "description": "Model Context Protocol server for Australian legislation and case law search with OCR fallbacks.",
+  "description": "Model Context Protocol server for Australian legislation and case law search.",
   "main": "dist/index.js",
   "bin": {
     "jurisd": "dist/index.js"
@@ -54,7 +54,6 @@
     "dotenv": "^17.4.2",
     "file-type": "^21.3.0",
     "pdf-parse": "^2.4.5",
-    "tmp": "^0.2.6",
     "zod": "^3.25.76"
   },
   "devDependencies": {
@@ -62,7 +61,6 @@
     "@eslint/js": "^9.39.4",
     "@types/cheerio": "^1.0.0",
     "@types/node": "^24.13.1",
-    "@types/tmp": "^0.2.6",
     "@typescript-eslint/eslint-plugin": "^8.60.1",
     "@typescript-eslint/parser": "^8.55.0",
     "@vitest/coverage-v8": "^4.1.8",

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,11 +39,6 @@ export interface Config {
     timeout: number;
     sessionCookie?: string;
   };
-  ocr: {
-    language: string;
-    oem: number;
-    psm: number;
-  };
   defaults: {
     searchLimit: number;
     maxSearchLimit: number;
@@ -148,11 +143,6 @@ export function loadConfig(): Config {
       userAgent: process.env.JADE_USER_AGENT || "jurisd/0.1.0 (legal research tool)",
       timeout: parseInt(process.env.JADE_TIMEOUT || "15000", 10),
       sessionCookie: process.env.JADE_SESSION_COOKIE || undefined,
-    },
-    ocr: {
-      language: process.env.OCR_LANGUAGE || "eng",
-      oem: parseInt(process.env.OCR_OEM || "1", 10),
-      psm: parseInt(process.env.OCR_PSM || "3", 10),
     },
     defaults: {
       searchLimit: parseInt(process.env.DEFAULT_SEARCH_LIMIT || "10", 10),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -82,9 +82,6 @@ export const JURISDICTIONS = {
   NEW_ZEALAND: "nz",
 } as const;
 
-/** Minimum text length before OCR fallback is triggered */
-export const OCR_MIN_TEXT_LENGTH = 100;
-
 /** Default HTTP timeout in milliseconds */
 export const DEFAULT_TIMEOUT_MS = 30_000;
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -84,17 +84,3 @@ export class ParseError extends Error {
     this.name = "ParseError";
   }
 }
-
-/**
- * Error thrown when OCR processing fails.
- */
-export class OcrError extends Error {
-  constructor(
-    message: string,
-    public readonly filePath?: string,
-    public readonly cause?: Error,
-  ) {
-    super(message);
-    this.name = "OcrError";
-  }
-}

--- a/src/server.ts
+++ b/src/server.ts
@@ -114,7 +114,7 @@ export function createMcpServer(): McpServer {
   const server = new McpServer({
     name: "jurisd",
     version: "0.1.0",
-    description: "Australian legislation and case law searcher with OCR-aware document retrieval.",
+    description: "Australian legislation and case law searcher with document retrieval.",
   });
 
   // ── search_legislation ────────────────────────────────────────────────────
@@ -206,7 +206,7 @@ export function createMcpServer(): McpServer {
     {
       title: "Fetch Document Text",
       description:
-        "Fetch full text for a legislation or case URL (AustLII or jade.io), with OCR fallback for scanned PDFs. When a `citeKey` is supplied and AUSLAW_FETCH_SOURCES is not set to 'false', also saves a local markdown copy to the sources directory and updates the cache entry's HTTP freshness headers. Without `citeKey`, only the document text is returned.",
+        "Fetch full text for a legislation or case URL (AustLII or jade.io). When a `citeKey` is supplied and AUSLAW_FETCH_SOURCES is not set to 'false', also saves a local markdown copy to the sources directory and updates the cache entry's HTTP freshness headers. Without `citeKey`, only the document text is returned.",
       inputSchema: fetchDocumentShape,
     },
     async (rawInput) => {

--- a/src/services/fetcher.ts
+++ b/src/services/fetcher.ts
@@ -2,15 +2,6 @@ import axios from "axios";
 import * as cheerio from "cheerio";
 import { fileTypeFromBuffer } from "file-type";
 import { PDFParse } from "pdf-parse";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import * as tmp from "tmp";
-import * as fs from "fs/promises";
-
-// Promisified execFile — passes argv as an array so shell metacharacters in
-// any argument are not interpreted. Replaces the abandoned node-tesseract-ocr
-// package (GHSA-8j44-735h-w4w2: OS command injection via recognize() params).
-const execFileAsync = promisify(execFile);
 import { config } from "../config.js";
 import { MAX_CONTENT_LENGTH } from "../constants.js";
 import { isJadeUrl, extractArticleId, fetchJadeArticleContent } from "./jade.js";
@@ -39,73 +30,22 @@ export interface FetchResponse {
   html?: string;
   contentType: string;
   sourceUrl: string;
-  ocrUsed: boolean;
   metadata?: Record<string, string>;
   paragraphs?: ParagraphBlock[];
   etag?: string;
   lastModified?: string;
 }
 
-async function extractTextFromPdf(
-  buffer: Buffer,
-  url: string,
-): Promise<{ text: string; ocrUsed: boolean }> {
+async function extractTextFromPdf(buffer: Buffer, url: string): Promise<string> {
   try {
-    // First try to extract text from PDF directly using pdf-parse v2 API
+    // Extract the embedded text layer of the PDF via pdf-parse v2.
     const parser = new PDFParse({ data: new Uint8Array(buffer) });
     const textResult = await parser.getText();
     await parser.destroy();
-    const extractedText = textResult.text.trim();
-
-    // If we got substantial text, return it
-    if (extractedText.length > 100) {
-      return { text: extractedText, ocrUsed: false };
-    }
-
-    // Otherwise, fall back to OCR
-    console.warn(`PDF at ${url} has minimal text, attempting OCR...`);
-    return await performOcr(buffer);
+    return textResult.text.trim();
   } catch (error) {
-    console.warn(`PDF parsing failed for ${url}, attempting OCR:`, error);
-    return await performOcr(buffer);
-  }
-}
-
-/**
- * Tesseract OCR via direct execFile (no shell). All arguments are passed
- * as an argv array so shell metacharacters cannot be interpreted. The input
- * path is a locally-generated tempfile (not user-controlled), and the OCR
- * config values come from env-var-backed `config.ocr.*` fields.
- */
-async function performOcr(buffer: Buffer): Promise<{ text: string; ocrUsed: boolean }> {
-  const tmpFile = tmp.fileSync({ postfix: ".pdf" });
-  try {
-    await fs.writeFile(tmpFile.name, buffer);
-
-    // tesseract CLI: `tesseract <input> stdout -l <lang> --oem <n> --psm <n>`
-    // Writing to stdout avoids a second tempfile for the output.
-    const args = [
-      tmpFile.name,
-      "stdout",
-      "-l",
-      String(config.ocr.language),
-      "--oem",
-      String(config.ocr.oem),
-      "--psm",
-      String(config.ocr.psm),
-    ];
-
-    const { stdout } = await execFileAsync("tesseract", args, {
-      // Allow up to 50 MB of recognised text — PDFs of full judgments can be large.
-      maxBuffer: 50 * 1024 * 1024,
-      // Fail fast on stuck tesseract (should never take more than a couple minutes).
-      timeout: 180_000,
-    });
-    return { text: stdout.trim(), ocrUsed: true };
-  } catch (error) {
-    throw new Error(`OCR failed: ${error instanceof Error ? error.message : String(error)}`);
-  } finally {
-    tmpFile.removeCallback();
+    console.warn(`PDF parsing failed for ${url}:`, error);
+    return "";
   }
 }
 
@@ -253,7 +193,7 @@ function extractParagraphBlocks(html: string): ParagraphBlock[] {
 
 /**
  * Parses a fetched document body (Buffer + content-type) into a
- * {@link FetchResponse}, driving the PDF/OCR, HTML and plain-text paths off the
+ * {@link FetchResponse}, driving the PDF, HTML and plain-text paths off the
  * detected content type. Shared by the AustLII (impit) and generic (axios)
  * fetch paths so both parse identically.
  *
@@ -275,14 +215,11 @@ async function parseDocumentBuffer(
 
   let text: string;
   let cleanedHtml: string | undefined;
-  let ocrUsed = false;
   let paragraphs: ParagraphBlock[] | undefined;
 
   // Handle PDF documents
   if (contentType.includes("application/pdf") || detectedType?.mime === "application/pdf") {
-    const result = await extractTextFromPdf(buffer, url);
-    text = result.text;
-    ocrUsed = result.ocrUsed;
+    text = await extractTextFromPdf(buffer, url);
   }
   // Handle HTML documents
   else if (contentType.includes("text/html") || detectedType?.mime === "text/html") {
@@ -315,7 +252,6 @@ async function parseDocumentBuffer(
     html: cleanedHtml,
     contentType: contentType || detectedType?.mime || "unknown",
     sourceUrl: url,
-    ocrUsed,
     metadata,
     paragraphs,
     etag: extra?.etag,
@@ -383,8 +319,7 @@ async function fetchAustliiDocument(url: string): Promise<FetchResponse> {
 /**
  * Fetches a legal document from a URL and extracts its text content.
  *
- * Supports HTML pages, PDF documents, and plain text. For scanned PDFs
- * with minimal extractable text the function falls back to Tesseract OCR.
+ * Supports HTML pages, PDF documents, and plain text.
  *
  * AustLII URLs are routed through the impit transport with Cloudflare-challenge
  * detection and an OALC corpus fallback; jade.io and all other URLs are
@@ -441,7 +376,6 @@ export async function fetchDocumentText(url: string): Promise<FetchResponse> {
       html: cleanedHtml,
       contentType: "text/html",
       sourceUrl: url,
-      ocrUsed: false,
       metadata: {
         contentLength: String(html.length),
         contentType: "text/html",

--- a/src/test/scenarios.test.ts
+++ b/src/test/scenarios.test.ts
@@ -146,7 +146,6 @@ describeLive("Real-world legal search scenarios", () => {
       expect(doc.text.length).toBeGreaterThan(100);
       expect(doc.sourceUrl).toBe(results[0].url);
       expect(doc.contentType).toBeTruthy();
-      expect(typeof doc.ocrUsed).toBe("boolean");
     }
   }, 60000); // Longer timeout for fetch
 });

--- a/src/test/smoke/fetcher.smoke.test.ts
+++ b/src/test/smoke/fetcher.smoke.test.ts
@@ -16,7 +16,6 @@ describe("fetchDocumentText", () => {
       );
       expect(result.text).toContain("Mabo");
       expect(result.contentType).toMatch(/text\/html/);
-      expect(result.ocrUsed).toBe(false);
       expect(result.sourceUrl).toContain("HCA/1992/23");
     },
     30_000,

--- a/src/test/unit/constants.test.ts
+++ b/src/test/unit/constants.test.ts
@@ -4,7 +4,6 @@ import {
   REPORTED_CITATION_PATTERNS,
   SEARCH_METHODS,
   JURISDICTIONS,
-  OCR_MIN_TEXT_LENGTH,
   DEFAULT_TIMEOUT_MS,
   LONG_TIMEOUT_MS,
   MAX_CONTENT_LENGTH,
@@ -60,7 +59,6 @@ describe("Constants", () => {
 
   describe("Numeric constants", () => {
     it("should have sensible values", () => {
-      expect(OCR_MIN_TEXT_LENGTH).toBe(100);
       expect(DEFAULT_TIMEOUT_MS).toBe(30_000);
       expect(LONG_TIMEOUT_MS).toBe(60_000);
       expect(MAX_CONTENT_LENGTH).toBe(50 * 1024 * 1024);

--- a/src/test/unit/errors.test.ts
+++ b/src/test/unit/errors.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  AustLiiError,
-  CloudflareBlockedError,
-  NetworkError,
-  ParseError,
-  OcrError,
-} from "../../errors.js";
+import { AustLiiError, CloudflareBlockedError, NetworkError, ParseError } from "../../errors.js";
 
 describe("Custom error classes", () => {
   describe("AustLiiError", () => {
@@ -84,15 +78,6 @@ describe("Custom error classes", () => {
       const err = new ParseError("invalid html", "<html>broken");
       expect(err.name).toBe("ParseError");
       expect(err.content).toBe("<html>broken");
-      expect(err).toBeInstanceOf(Error);
-    });
-  });
-
-  describe("OcrError", () => {
-    it("should store filePath", () => {
-      const err = new OcrError("tesseract crashed", "/tmp/doc.pdf");
-      expect(err.name).toBe("OcrError");
-      expect(err.filePath).toBe("/tmp/doc.pdf");
       expect(err).toBeInstanceOf(Error);
     });
   });

--- a/src/test/unit/fetcher-jade.test.ts
+++ b/src/test/unit/fetcher-jade.test.ts
@@ -28,7 +28,6 @@ vi.mock("../../config.js", () => ({
       sessionCookie: "IID=test; alcsessionid=abc",
       baseUrl: "https://jade.io",
     },
-    ocr: { language: "eng", oem: 1, psm: 3 },
     austlii: { searchBase: "", referer: "", userAgent: "", timeout: 5000 },
     defaults: { searchLimit: 10, maxSearchLimit: 50, outputFormat: "json", sortBy: "auto" },
   },
@@ -143,7 +142,6 @@ describe("fetchDocumentText — jade.io GWT-RPC paths", () => {
 
     const result = await fetchDocumentText(JADE_ARTICLE_URL);
     expect(result.contentType).toBe("text/html");
-    expect(result.ocrUsed).toBe(false);
     expect(result.sourceUrl).toBe(JADE_ARTICLE_URL);
     expect(result.metadata?.source).toBe("jade-gwt-rpc");
   });

--- a/src/test/unit/fetcher-mock.test.ts
+++ b/src/test/unit/fetcher-mock.test.ts
@@ -51,7 +51,6 @@ const mockConfig = vi.hoisted(() => ({
     baseUrl: "https://jade.io",
   },
   oalc: { enabled: true, source: "/tmp/fixture.jsonl" },
-  ocr: { language: "eng", oem: 1, psm: 3 },
 }));
 
 vi.mock("../../config.js", () => ({ config: mockConfig }));

--- a/src/test/unit/fetcher-pdf.test.ts
+++ b/src/test/unit/fetcher-pdf.test.ts
@@ -1,12 +1,11 @@
 /**
- * Tests for fetchDocumentText PDF and OCR paths.
- * Requires mocking child_process (Tesseract), pdf-parse, tmp, and fs/promises.
+ * Tests for fetchDocumentText PDF handling (pdf-parse digital text extraction).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fileTypeFromBuffer } from "file-type";
 
 // AustLII PDFs route through the impit transport seam. Mock that seam (not
-// axios) to return the PDF bytes so the shared PDF/OCR parse path runs offline.
+// axios) to return the PDF bytes so the shared PDF parse path runs offline.
 const { getMock, fetcherForUrlMock } = vi.hoisted(() => {
   const getMock = vi.fn();
   const fetcherForUrlMock = vi.fn(() => ({ get: getMock }));
@@ -16,31 +15,6 @@ vi.mock("../../services/transport.js", () => ({ fetcherForUrl: fetcherForUrlMock
 vi.mock("../../services/cloudflare.js", () => ({
   isCloudflareChallenge: vi.fn().mockReturnValue(false),
 }));
-
-// ── Hoisted mock references ────────────────────────────────────────────────
-
-// execFileAsync mock: add the Node.js custom promisify symbol so that
-// promisify(execFile) in fetcher.ts wraps this function, preserving
-// the { stdout, stderr } resolved-value shape.
-const mockExecFileAsync = vi.hoisted(() => vi.fn().mockResolvedValue({ stdout: "", stderr: "" }));
-
-vi.mock("node:child_process", () => {
-  const fn = vi.fn(); // the raw execFile mock (used by promisify internally)
-  Object.defineProperty(fn, Symbol.for("nodejs.util.promisify.custom"), {
-    value: mockExecFileAsync,
-    writable: true,
-    configurable: true,
-  });
-  return { execFile: fn };
-});
-
-// tmp mock — fileSync returns a fake temp file handle
-vi.mock("tmp", () => ({
-  fileSync: vi.fn(() => ({ name: "/tmp/test-ocr.pdf", removeCallback: vi.fn() })),
-}));
-
-// fs/promises mock — only writeFile is called in the OCR path
-vi.mock("fs/promises", () => ({ writeFile: vi.fn().mockResolvedValue(undefined) }));
 
 // pdf-parse mock — use a class so `new PDFParse()` works correctly with clearMocks:true
 const mockGetText = vi.hoisted(() => vi.fn());
@@ -62,7 +36,6 @@ vi.mock("../../config.js", () => ({
       sessionCookie: undefined,
       baseUrl: "https://jade.io",
     },
-    ocr: { language: "eng", oem: 1, psm: 3 },
     austlii: {
       searchBase: "",
       referer: "",
@@ -104,65 +77,31 @@ describe("fetchDocumentText — PDF content type", () => {
     mockGetText.mockReset();
     mockDestroy.mockReset();
     mockDestroy.mockResolvedValue(undefined);
-    mockExecFileAsync.mockReset();
-    mockExecFileAsync.mockResolvedValue({ stdout: "", stderr: "" });
   });
 
-  it("extracts text directly when PDF has substantial text (>100 chars)", async () => {
+  it("extracts the embedded text layer of a digital PDF", async () => {
     const longText = "A".repeat(200);
     mockGetText.mockResolvedValue({ text: longText });
     mockPdfAxiosResponse();
 
     const result = await fetchDocumentText(PDF_URL);
-    expect(result.ocrUsed).toBe(false);
     expect(result.text).toBe(longText);
     expect(result.contentType).toContain("application/pdf");
   });
 
-  it("falls back to OCR when PDF text is too short (<=100 chars)", async () => {
-    mockGetText.mockResolvedValue({ text: "short text" }); // <100 chars → triggers OCR
-    mockExecFileAsync.mockResolvedValue({
-      stdout: "OCR extracted text from scanned PDF",
-      stderr: "",
-    });
+  it("returns the extracted text as-is when it is short", async () => {
+    mockGetText.mockResolvedValue({ text: "short text" });
     mockPdfAxiosResponse();
 
     const result = await fetchDocumentText(PDF_URL);
-    expect(result.ocrUsed).toBe(true);
-    expect(result.text).toBe("OCR extracted text from scanned PDF");
+    expect(result.text).toBe("short text");
   });
 
-  it("falls back to OCR when pdf-parse throws", async () => {
+  it("returns empty text when pdf-parse fails", async () => {
     mockGetText.mockRejectedValue(new Error("Invalid PDF structure"));
-    mockExecFileAsync.mockResolvedValue({ stdout: "OCR text from fallback", stderr: "" });
     mockPdfAxiosResponse();
 
     const result = await fetchDocumentText(PDF_URL);
-    expect(result.ocrUsed).toBe(true);
-    expect(result.text).toBe("OCR text from fallback");
-  });
-
-  it("throws with OCR-failed message when Tesseract exits with error", async () => {
-    mockGetText.mockResolvedValue({ text: "tiny" }); // triggers OCR
-    mockExecFileAsync.mockRejectedValue(new Error("tesseract: command not found"));
-    mockPdfAxiosResponse();
-
-    await expect(fetchDocumentText(PDF_URL)).rejects.toThrow("OCR failed");
-  });
-
-  it("cleans up temp file even when OCR fails", async () => {
-    const { fileSync } = await import("tmp");
-    const removeSpy = vi.fn();
-    vi.mocked(fileSync).mockReturnValueOnce({
-      name: "/tmp/cleanup-test.pdf",
-      removeCallback: removeSpy,
-    } as unknown as ReturnType<typeof fileSync>);
-
-    mockGetText.mockResolvedValue({ text: "tiny" });
-    mockExecFileAsync.mockRejectedValue(new Error("tesseract not found"));
-    mockPdfAxiosResponse();
-
-    await expect(fetchDocumentText(PDF_URL)).rejects.toThrow();
-    expect(removeSpy).toHaveBeenCalled();
+    expect(result.text).toBe("");
   });
 });

--- a/src/test/unit/fetcher.test.ts
+++ b/src/test/unit/fetcher.test.ts
@@ -22,7 +22,6 @@ const mockConfig = vi.hoisted(() => ({
     sessionCookie: undefined as string | undefined,
     baseUrl: "https://jade.io",
   },
-  ocr: { language: "eng", oem: 1, psm: 3 },
   austlii: {
     searchBase: "",
     referer: "",

--- a/src/test/unit/formatter.test.ts
+++ b/src/test/unit/formatter.test.ts
@@ -34,7 +34,6 @@ const sampleFetch: FetchResponse = {
   text: "This is a sample judgement text.",
   contentType: "text/html",
   sourceUrl: "https://www.austlii.edu.au/au/cases/cth/HCA/1992/23.html",
-  ocrUsed: false,
   metadata: { contentLength: "123" },
 };
 
@@ -117,7 +116,6 @@ it("ensureContent returns empty-text content item when given empty string", () =
     text: "",
     contentType: "text/plain",
     sourceUrl: "https://example.com",
-    ocrUsed: false,
   };
   const result = formatFetchResponse(response as Parameters<typeof formatFetchResponse>[0], "text");
   expect(result.content).toHaveLength(1);
@@ -207,7 +205,6 @@ describe("formatFetchResponse", () => {
     expect(() => JSON.parse(text)).not.toThrow();
     const parsed = JSON.parse(text);
     expect(parsed.sourceUrl).toBe(sampleFetch.sourceUrl);
-    expect(parsed.ocrUsed).toBe(false);
   });
 
   it("should format fetch response as text", () => {
@@ -229,7 +226,6 @@ describe("formatFetchResponse", () => {
     const text = getText(result.content);
     expect(text).toContain("<article");
     expect(text).toContain("data-source=");
-    expect(text).toContain("data-ocr=");
   });
 
   it("should use preserved HTML structure when available", () => {

--- a/src/test/unit/jade-citator.test.ts
+++ b/src/test/unit/jade-citator.test.ts
@@ -13,7 +13,6 @@ const mockConfig = vi.hoisted(() => ({
     sessionCookie: undefined as string | undefined,
     baseUrl: "https://jade.io",
   },
-  ocr: { language: "eng", oem: 1, psm: 3 },
   austlii: { searchBase: "", referer: "", userAgent: "", timeout: 5000 },
   defaults: {
     searchLimit: 10,

--- a/src/test/unit/jade-search.test.ts
+++ b/src/test/unit/jade-search.test.ts
@@ -13,7 +13,6 @@ const mockConfig = vi.hoisted(() => ({
     sessionCookie: undefined as string | undefined,
     baseUrl: "https://jade.io",
   },
-  ocr: { language: "eng", oem: 1, psm: 3 },
   austlii: { searchBase: "", referer: "", userAgent: "", timeout: 5000 },
   defaults: {
     searchLimit: 10,

--- a/src/test/unit/source-store.test.ts
+++ b/src/test/unit/source-store.test.ts
@@ -104,7 +104,6 @@ describe("storeSource", () => {
       text: SAMPLE_TEXT,
       contentType: "text/html",
       sourceUrl: TEST_URL,
-      ocrUsed: false,
     });
     // HEAD for ETag capture after fetch
     vi.mocked(axios.head).mockResolvedValue({

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -126,7 +126,7 @@ export function formatFetchResponse(
       }
       return {
         content: ensureContent(
-          `<article data-source="${escapeHtml(response.sourceUrl)}" data-ocr="${String(response.ocrUsed)}"><pre>${escapeHtml(response.text)}</pre></article>`,
+          `<article data-source="${escapeHtml(response.sourceUrl)}"><pre>${escapeHtml(response.text)}</pre></article>`,
         ),
       };
     case "markdown":


### PR DESCRIPTION
## Summary

Excises the OCR code path from jurisd. **Scope is OCR only** — jade.io, AustLII, the OALC layer, Isaacus and `JADE_SESSION_COOKIE` are untouched. Reversible via git history if ever wanted back.

`pdf-parse` digital-PDF text extraction is **retained** (that's not OCR). Only the Tesseract optical-recognition fallback is removed; it depended on a `tesseract` binary that was never bundled in the Dockerfile or CI, so it only ever worked on hosts that happened to have it installed. Scanned/image-only PDFs now return empty text instead of shelling out.

## What changed

- `src/services/fetcher.ts` — removed `performOcr()`, the OCR fallback in `extractTextFromPdf()` (now returns `Promise<string>`), the `ocrUsed` field on `FetchResponse`, and the OCR-only imports (`execFile`/`promisify`/`tmp`/`fs`).
- `src/utils/formatter.ts` — dropped the `data-ocr` HTML attribute.
- `src/config.ts` — removed `config.ocr` (interface + value).
- `src/constants.ts` — removed `OCR_MIN_TEXT_LENGTH`.
- `src/errors.ts` — removed the unused `OcrError` class.
- `src/server.ts` / `package.json` — dropped OCR wording from the MCP server + tool descriptions and the package description.
- `package.json` — dropped `tmp` + `@types/tmp` deps.
- `config.yaml` / `k8s/configmap.yaml` — removed the `ocr` block and `OCR_*` env keys.
- Tests — trimmed `fetcher-pdf.test.ts` to the digital-extraction path + new no-OCR behaviour; removed `ocrUsed`/`OcrError`/`OCR_MIN_TEXT_LENGTH` assertions and stale `ocr:` config fixtures across the suite.
- `CHANGELOG.md` — one-line Removed entry (no other prose docs touched, by request).

## Verification

- `npm run build` — clean (tsc)
- `npx vitest run src/test/unit/` — **1227 passed, 0 failed**
- ESLint on all changed files — no issues
- Grep gate — zero `ocr`/`tesseract` references in `src/*.ts`

## Deploy note

No workflow auto-deploys on this branch/PR (`docker.yml` image build is `push: branches: [main]`; `release.yml` is tag-only; nothing runs ArgoCD/kubectl). On **merge to main**, `docker.yml` will build a new image. The `k8s/configmap.yaml` edit only drops now-unused `OCR_*` keys, so it is non-disruptive to the running service.