### PR TITLE
feat(cli): expose all 15 MCP tools as jurisd subcommands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,16 +2,31 @@
  * Thin CLI subcommand dispatch.
  *
  * The entry point branches on `process.argv` before the server starts. No
- * heavyweight CLI framework — a thin switch over the first positional arg:
+ * heavyweight CLI framework — a thin switch over the first positional arg.
  *
- *   jurisd fetch-module <name> [--version X.Y.Z] [--manifest-url URL] [--modules-dir DIR]
- *   jurisd verify-module <name> [--modules-dir DIR]
- *   jurisd list-modules [--modules-dir DIR]
+ * Two families of subcommand exist:
  *
- * Returns true when a subcommand was handled (and the process should exit), or
- * false when no subcommand was given and the server should start.
+ *   Module management (run directly, before the server):
+ *     jurisd fetch-module <name> [--version X.Y.Z] [--manifest-url URL] [--modules-dir DIR]
+ *     jurisd verify-module <name> [--modules-dir DIR]
+ *     jurisd list-modules [--modules-dir DIR]
+ *
+ *   MCP-tool parity (routed through an in-process loopback to the SAME handlers
+ *   any MCP client would hit, so the CLI cannot drift from the protocol):
+ *     jurisd search-cases <query> [--jurisdiction nsw] [--limit 10] ...
+ *     jurisd get-provision <act> <provision> ...
+ *     jurisd format-citation <title> --neutral-citation '[1992] HCA 23' ...
+ *     ... one subcommand per registered tool.
+ *
+ * `runCli` returns true when a subcommand was handled (and the process should
+ * exit via `process.exitCode`), or false when no subcommand was given and the
+ * server should start.
  */
 
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { createMcpServer } from "./server.js";
 import { fetchModule, verifyModule } from "./services/fetch-module.js";
 import { listDataModules, setModulesRootForTest } from "./services/modules.js";
 
@@ -37,12 +52,265 @@ function parseFlags(args: string[]): { positional: string[]; flags: Record<strin
 }
 
 /**
+ * Declarative mapping from a CLI subcommand to its registered MCP tool.
+ *
+ * `positional` lists the required-first schema fields that may be supplied
+ * positionally, in order. Every other schema field is accepted as a flag whose
+ * kebab-case name maps to the camelCase field (e.g. `--neutral-citation` ->
+ * `neutralCitation`). `numeric`/`boolean`/`array` declare the coercion applied
+ * to a flag's string value; anything else passes through as a string.
+ */
+interface ToolCommand {
+  tool: string;
+  positional: string[];
+  numeric: string[];
+  boolean: string[];
+  array: string[];
+}
+
+const TOOL_COMMANDS: Record<string, ToolCommand> = {
+  "search-cases": {
+    tool: "search_cases",
+    positional: ["query"],
+    numeric: ["limit", "offset"],
+    boolean: [],
+    array: [],
+  },
+  "search-legislation": {
+    tool: "search_legislation",
+    positional: ["query"],
+    numeric: ["limit", "offset"],
+    boolean: [],
+    array: [],
+  },
+  "resolve-citation": {
+    tool: "resolve_citation",
+    positional: ["citation"],
+    numeric: [],
+    boolean: [],
+    array: [],
+  },
+  "format-citation": {
+    tool: "format_citation",
+    positional: ["title"],
+    numeric: ["footnoteRef", "pinpointPara", "pinpointPage", "paragraphNumber"],
+    boolean: [],
+    array: [],
+  },
+  "get-provision": {
+    tool: "get_provision",
+    positional: ["act", "provision"],
+    numeric: [],
+    boolean: [],
+    array: [],
+  },
+  "get-act-structure": {
+    tool: "get_act_structure",
+    positional: ["act"],
+    numeric: ["depth"],
+    boolean: [],
+    array: [],
+  },
+  "find-citing": {
+    tool: "find_citing",
+    positional: ["target"],
+    numeric: ["limit"],
+    boolean: [],
+    array: ["kinds"],
+  },
+  "semantic-search-local": {
+    tool: "semantic_search_local",
+    positional: ["query"],
+    numeric: ["k"],
+    boolean: [],
+    array: [],
+  },
+  "list-data-modules": {
+    tool: "list_data_modules",
+    positional: [],
+    numeric: [],
+    boolean: ["refresh", "includeInvalid"],
+    array: [],
+  },
+  "search-citing-cases": {
+    tool: "search_citing_cases",
+    positional: ["caseName"],
+    numeric: [],
+    boolean: [],
+    array: [],
+  },
+  "cache-cited-by": {
+    tool: "cache_cited_by",
+    positional: ["citeKey"],
+    numeric: [],
+    boolean: [],
+    array: [],
+  },
+  bibliography: {
+    tool: "bibliography",
+    positional: [],
+    numeric: [],
+    boolean: [],
+    array: [],
+  },
+  cite: {
+    tool: "cite",
+    positional: ["title"],
+    numeric: ["year", "footnoteNumber"],
+    boolean: [],
+    array: ["keywords"],
+  },
+  "jade-lookup": {
+    tool: "jade_lookup",
+    positional: [],
+    numeric: ["articleId"],
+    boolean: [],
+    array: [],
+  },
+  "fetch-document-text": {
+    tool: "fetch_document_text",
+    positional: ["url"],
+    numeric: [],
+    boolean: [],
+    array: [],
+  },
+};
+
+/** Convert a kebab-case flag name to the camelCase schema field it targets. */
+function flagToField(flag: string): string {
+  return flag.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+/**
+ * `semantic_search_local` accepts a nested `filter` object. Flags of the form
+ * `--filter-<facet>` are folded into that object so the CLI can express it
+ * without bespoke parsing per facet.
+ */
+function applyFilterFlag(args: Record<string, unknown>, field: string, value: string): void {
+  const facet = field.slice("filter".length);
+  const key = facet.charAt(0).toLowerCase() + facet.slice(1);
+  const filter = (args.filter as Record<string, unknown> | undefined) ?? {};
+  filter[key] = value;
+  args.filter = filter;
+}
+
+/**
+ * Pure mapping from parsed argv to a tool `arguments` object. Positional values
+ * fill the command's positional fields in order; flags fill the remaining
+ * fields with type coercion. Kept side-effect free so it is unit-testable
+ * without a live loopback.
+ */
+export function mapArgvToToolInput(
+  command: ToolCommand,
+  positional: string[],
+  flags: Record<string, string>,
+): Record<string, unknown> {
+  const args: Record<string, unknown> = {};
+
+  command.positional.forEach((field, i) => {
+    const value = positional[i];
+    if (value !== undefined) args[field] = value;
+  });
+
+  for (const [flag, raw] of Object.entries(flags)) {
+    if (flag === "modules-dir") continue;
+    const field = flagToField(flag);
+    if (field.startsWith("filter") && field.length > "filter".length) {
+      applyFilterFlag(args, field, raw);
+    } else if (command.numeric.includes(field)) {
+      args[field] = Number(raw);
+    } else if (command.boolean.includes(field)) {
+      args[field] = raw === "" ? true : raw === "true";
+    } else if (command.array.includes(field)) {
+      args[field] = raw.split(",").map((s) => s.trim());
+    } else {
+      args[field] = raw;
+    }
+  }
+
+  return args;
+}
+
+/** Run a tool through the in-process loopback and stream its result to stdout. */
+async function runToolCommand(
+  command: ToolCommand,
+  positional: string[],
+  flags: Record<string, string>,
+): Promise<void> {
+  const args = mapArgvToToolInput(command, positional, flags);
+
+  const server = createMcpServer();
+  const client = new Client({ name: "jurisd-cli", version: "0.1.0" }, { capabilities: {} });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+  try {
+    const result = await client.callTool({ name: command.tool, arguments: args });
+    const content = (result.content ?? []) as Array<{ type: string; text?: string }>;
+    for (const block of content) {
+      if (block.type === "text" && block.text !== undefined) {
+        process.stdout.write(block.text + "\n");
+      }
+    }
+    process.exitCode = result.isError ? 1 : 0;
+  } finally {
+    // Settle both teardowns independently so a failing client close cannot
+    // skip the server close (or mask an earlier error) on any transport.
+    await Promise.allSettled([client.close(), server.close()]);
+  }
+}
+
+/** One-line usage banner listing every available subcommand. */
+function printHelp(): void {
+  const toolCmds = Object.keys(TOOL_COMMANDS).sort().join(", ");
+  console.error("jurisd — Australian/NZ legal research");
+  console.error("");
+  console.error("Module management:");
+  console.error("  fetch-module <name> [--version X.Y.Z] [--manifest-url URL] [--modules-dir DIR]");
+  console.error("  verify-module <name> [--modules-dir DIR]");
+  console.error("  list-modules [--modules-dir DIR]");
+  console.error("");
+  console.error("Tools (parity with the MCP surface):");
+  console.error(`  ${toolCmds}`);
+  console.error("");
+  console.error("Run with no subcommand to start the MCP server.");
+}
+
+/**
  * Handle a CLI subcommand. Returns true when handled (process should exit with
  * `process.exitCode`), false when no subcommand was given.
  */
 export async function runCli(argv: string[]): Promise<boolean> {
   const [command, ...rest] = argv;
-  if (!command || command.startsWith("--")) return false;
+  if (!command || command.startsWith("--")) {
+    if (command === "--help") {
+      printHelp();
+      process.exitCode = 0;
+      return true;
+    }
+    return false;
+  }
+
+  if (command === "help") {
+    printHelp();
+    process.exitCode = 0;
+    return true;
+  }
+
+  const toolCommand = TOOL_COMMANDS[command];
+  if (toolCommand) {
+    const { positional, flags } = parseFlags(rest);
+    if (flags["modules-dir"]) setModulesRootForTest(flags["modules-dir"], true);
+    if (positional.length < toolCommand.positional.length) {
+      const fields = toolCommand.positional.map((f) => `<${f}>`).join(" ");
+      console.error(`usage: jurisd ${command} ${fields} [--flag value ...]`);
+      process.exitCode = 2;
+      return true;
+    }
+    await runToolCommand(toolCommand, positional, flags);
+    return true;
+  }
+
   if (!["fetch-module", "verify-module", "list-modules"].includes(command)) return false;
 
   const { positional, flags } = parseFlags(rest);

--- a/src/test/unit/cli.test.ts
+++ b/src/test/unit/cli.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { runCli, mapArgvToToolInput } from "../../cli.js";
+import { setModulesRootForTest } from "../../services/modules.js";
+
+/**
+ * The argv -> tool-input mapping is exercised here independently of any live
+ * loopback so the coercion rules can be asserted offline. The mapping shapes
+ * below mirror the registry entries in cli.ts; they are intentionally inlined
+ * so the test pins the contract a caller relies on.
+ */
+const searchCasesCmd = {
+  tool: "search_cases",
+  positional: ["query"],
+  numeric: ["limit", "offset"],
+  boolean: [],
+  array: [],
+};
+const resolveCitationCmd = {
+  tool: "resolve_citation",
+  positional: ["citation"],
+  numeric: [],
+  boolean: [],
+  array: [],
+};
+const findCitingCmd = {
+  tool: "find_citing",
+  positional: ["target"],
+  numeric: ["limit"],
+  boolean: [],
+  array: ["kinds"],
+};
+const listDataModulesCmd = {
+  tool: "list_data_modules",
+  positional: [],
+  numeric: [],
+  boolean: ["refresh", "includeInvalid"],
+  array: [],
+};
+const semanticCmd = {
+  tool: "semantic_search_local",
+  positional: ["query"],
+  numeric: ["k"],
+  boolean: [],
+  array: [],
+};
+
+describe("mapArgvToToolInput", () => {
+  it("assigns a positional to the first schema field", () => {
+    const args = mapArgvToToolInput(searchCasesCmd, ["misleading conduct"], {});
+    expect(args).toEqual({ query: "misleading conduct" });
+  });
+
+  it("coerces numeric flags to numbers", () => {
+    const args = mapArgvToToolInput(searchCasesCmd, ["native title"], {
+      limit: "5",
+      offset: "50",
+    });
+    expect(args.query).toBe("native title");
+    expect(args.limit).toBe(5);
+    expect(args.offset).toBe(50);
+    expect(typeof args.limit).toBe("number");
+  });
+
+  it("passes enum flags through as strings", () => {
+    const args = mapArgvToToolInput(resolveCitationCmd, ["[1992] HCA 23"], {
+      mode: "validate",
+    });
+    expect(args).toEqual({ citation: "[1992] HCA 23", mode: "validate" });
+  });
+
+  it("splits array flags on commas and trims", () => {
+    const args = mapArgvToToolInput(findCitingCmd, ["Mabo v Queensland (No 2)"], {
+      kinds: "cites, considers",
+      limit: "20",
+    });
+    expect(args.kinds).toEqual(["cites", "considers"]);
+    expect(args.limit).toBe(20);
+  });
+
+  it("coerces boolean flags, treating a bare flag as true", () => {
+    const args = mapArgvToToolInput(listDataModulesCmd, [], {
+      refresh: "",
+      includeInvalid: "false",
+    });
+    expect(args.refresh).toBe(true);
+    expect(args.includeInvalid).toBe(false);
+  });
+
+  it("folds --filter-<facet> flags into a nested filter object", () => {
+    const args = mapArgvToToolInput(semanticCmd, ["restraint of trade"], {
+      k: "3",
+      "filter-jurisdiction": "cth",
+      "filter-type": "primary_legislation",
+    });
+    expect(args.k).toBe(3);
+    expect(args.filter).toEqual({ jurisdiction: "cth", type: "primary_legislation" });
+  });
+
+  it("ignores the loader-only --modules-dir flag", () => {
+    const args = mapArgvToToolInput(searchCasesCmd, ["x"], { "modules-dir": "/tmp/x" });
+    expect(args).toEqual({ query: "x" });
+  });
+});
+
+describe("runCli routing", () => {
+  beforeEach(() => {
+    process.exitCode = 0;
+  });
+  afterEach(() => {
+    process.exitCode = 0;
+  });
+
+  it("returns false when no command is given (server should start)", async () => {
+    expect(await runCli([])).toBe(false);
+  });
+
+  it("returns false for an unknown command", async () => {
+    expect(await runCli(["definitely-not-a-command"])).toBe(false);
+  });
+
+  it("returns false when the first arg is a flag", async () => {
+    expect(await runCli(["--http"])).toBe(false);
+  });
+});
+
+describe("runCli tool loopback (offline tools)", () => {
+  let scratch: string;
+  let stdout: ReturnType<typeof vi.spyOn>;
+  let stderr: ReturnType<typeof vi.spyOn>;
+  let written: string;
+
+  beforeEach(() => {
+    process.exitCode = 0;
+    scratch = fs.mkdtempSync(path.join(os.tmpdir(), "jurisd-cli-"));
+    setModulesRootForTest(scratch, true);
+    written = "";
+    stdout = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      written += String(chunk);
+      return true;
+    });
+    stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    stdout.mockRestore();
+    stderr.mockRestore();
+    setModulesRootForTest(null);
+    fs.rmSync(scratch, { recursive: true, force: true });
+    process.exitCode = 0;
+  });
+
+  it("list-data-modules runs through the loopback to stdout with exit 0", async () => {
+    const handled = await runCli(["list-data-modules"]);
+    expect(handled).toBe(true);
+    expect(process.exitCode).toBe(0);
+    const parsed = JSON.parse(written) as { count: number; modules: unknown[] };
+    expect(parsed.count).toBe(0);
+    expect(parsed.modules).toEqual([]);
+  });
+
+  it("format-citation full mode formats a citation to stdout with exit 0", async () => {
+    const handled = await runCli([
+      "format-citation",
+      "Mabo v Queensland (No 2)",
+      "--neutral-citation",
+      "[1992] HCA 23",
+      "--reported-citation",
+      "(1992) 175 CLR 1",
+    ]);
+    expect(handled).toBe(true);
+    expect(process.exitCode).toBe(0);
+    expect(written).toContain("Mabo v Queensland (No 2)");
+    expect(written).toContain("[1992] HCA 23");
+  });
+
+  it("semantic-search-local degrades to a typed note with exit 0 when the embedder is absent", async () => {
+    const handled = await runCli(["semantic-search-local", "restraint of trade"]);
+    expect(handled).toBe(true);
+    expect(process.exitCode).toBe(0);
+    // Either a typed note (no embedder / no module) or an empty result set;
+    // both are valid offline outcomes. The contract under test is that output
+    // lands on stdout and the exit code is success.
+    expect(written.length).toBeGreaterThan(0);
+    const parsed = JSON.parse(written) as Record<string, unknown>;
+    expect(parsed).toBeTypeOf("object");
+  });
+
+  it("sets exitCode 2 when a required positional is missing", async () => {
+    const handled = await runCli(["get-provision"]);
+    expect(handled).toBe(true);
+    expect(process.exitCode).toBe(2);
+    expect(written).toBe("");
+  });
+
+  it("sets exitCode 1 when the tool rejects invalid input (no network)", async () => {
+    // A syntactically invalid URL fails the tool's `z.string().url()` schema
+    // before the handler runs, so the loopback surfaces isError without any
+    // network call — pinning the result.isError -> exit 1 branch.
+    const handled = await runCli(["fetch-document-text", "not-a-valid-url"]);
+    expect(handled).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- **CLI parity:** every registered MCP tool is now runnable as `jurisd <subcommand> ...` from the command line (previously only the three module-management commands were CLI-reachable).
- Routed through an **in-process MCP loopback** (`InMemoryTransport` + `Client` connected to `createMcpServer()`), so the CLI hits the *same* handlers as any MCP client and cannot drift from the protocol. No tool logic is duplicated.
- Adds a declarative subcommand registry, a pure `mapArgvToToolInput` mapper (numeric/boolean/array coercion + nested `--filter-<facet>` folding), result streaming to **stdout**, status/usage/errors to **stderr**, and exit codes **0** (ok) / **1** (tool error) / **2** (usage).
- Existing `fetch-module` / `verify-module` / `list-modules` commands are unchanged.

Examples:

```
jurisd search-cases "misleading conduct" --jurisdiction nsw --limit 10
jurisd get-provision "Competition and Consumer Act 2010 (Cth)" "s 18"
jurisd resolve-citation "[1992] HCA 23" --mode validate
jurisd help
```

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run src/test/unit/cli.test.ts` — 15/15 (argv mapping, routing/exit-code contract, offline loopback for `list-data-modules` / `format-citation` / `semantic-search-local` degradation, and an invalid-input error path)
- [x] `npx vitest run src/test/unit/` — 627 passed, 1 skipped, 0 failed
- [x] `npx eslint src/cli.ts src/test/unit/cli.test.ts` — no issues

## Follow-ups (deliberately out of scope)

- `parseFlags` consumes the following token as a flag's value, so two adjacent valueless boolean flags misparse (`--refresh --include-invalid`); `--flag=true` is unambiguous. Pre-existing helper; worth fixing to treat a following `--token` as "no value".
- `setModulesRootForTest` is the production `--modules-dir` override despite its test-only name; consider renaming to `setModulesRoot`.