### PR TITLE
docs: drop OCR references and reframe jade.io as runtime citation enhancement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,6 @@ Please be respectful and constructive in all interactions. We are committed to p
 - Node.js 18.x or higher
 - npm or yarn package manager
 - Git
-- (Optional) Tesseract OCR for testing PDF functionality
 
 ### Setting Up Development Environment
 
@@ -292,7 +291,7 @@ src/
 ├── errors.ts             # Custom error classes
 ├── services/
 │   ├── austlii.ts       # AustLII search integration
-│   ├── jade.ts          # jade.io search & cross-referencing
+│   ├── jade.ts          # jade.io citation resolution & cross-referencing
 │   └── fetcher.ts       # Document text retrieval
 ├── utils/
 │   ├── formatter.ts     # Output formatting

--- a/LICENSE-THIRD-PARTY.md
+++ b/LICENSE-THIRD-PARTY.md
@@ -12,21 +12,20 @@ dependencies use permissive licenses compatible with this project's MIT license.
 | BSD-2-Clause  | 17    |
 | Apache-2.0    | 14    |
 | BSD-3-Clause  | 10    |
-| BlueOak-1.0.0 | 3    |
+| BlueOak-1.0.0 | 3     |
 | Python-2.0    | 1     |
 
 ## Key Production Dependencies
 
-| Package | License | Repository |
-| ------- | ------- | ---------- |
-| @modelcontextprotocol/sdk | MIT | https://github.com/modelcontextprotocol/typescript-sdk |
-| axios | MIT | https://github.com/axios/axios |
-| cheerio | MIT | https://github.com/cheeriojs/cheerio |
-| file-type | MIT | https://github.com/sindresorhus/file-type |
-| node-tesseract-ocr | MIT | https://github.com/nicolomaioli/node-tesseract-ocr |
-| pdf-parse | MIT | https://gitlab.com/nicolumaolo/pdf-parse |
-| tmp | MIT | https://github.com/raszi/node-tmp |
-| zod | MIT | https://github.com/colinhacks/zod |
+| Package                   | License | Repository                                             |
+| ------------------------- | ------- | ------------------------------------------------------ |
+| @modelcontextprotocol/sdk | MIT     | https://github.com/modelcontextprotocol/typescript-sdk |
+| axios                     | MIT     | https://github.com/axios/axios                         |
+| cheerio                   | MIT     | https://github.com/cheeriojs/cheerio                   |
+| file-type                 | MIT     | https://github.com/sindresorhus/file-type              |
+| pdf-parse                 | MIT     | https://gitlab.com/nicolumaolo/pdf-parse               |
+| tmp                       | MIT     | https://github.com/raszi/node-tmp                      |
+| zod                       | MIT     | https://github.com/colinhacks/zod                      |
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ assistant. It has three answer sources, tried in precedence order:
    an offline citation graph, and local semantic search.
 2. **Live AustLII (Layer 2)** — natural-language case and legislation search over
    AustLII, with authority-based ranking, paragraph-pinpoint extraction, full-text
-   fetch (HTML + PDF with OCR), and AGLC4 citation formatting.
+   fetch (HTML + PDF), and AGLC4 citation formatting.
 3. **OALC fallback (Layer 3)** — an Open Australian Legal Corpus layer that backs
    the live layer when a direct fetch is blocked.
 
-jade.io is supported as an authenticated source for search, full-text fetch, and
-the citator when you supply your own session cookie.
+jade.io is supported as an optional runtime citation-enhancement source — the
+citator (citing cases), citation/article resolution, and cross-referencing of
+live results — when you supply your own session cookie.
 
 ## Quick start
 
@@ -89,13 +90,13 @@ and AGLC4 prompts once the `jurisd` MCP server is registered.
 15 tools in three groups. Operation variants are selected via a
 `mode` / `op` / `action` / `by` discriminator on the relevant tool.
 
-### Live research (AustLII + jade.io)
+### Live research (AustLII)
 
 | Tool                  | What it does                                                                                                                  |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | `search_cases`        | Natural-language case-law search across all AU/NZ jurisdictions; authority ranking; title/phrase/boolean methods; pagination. |
 | `search_legislation`  | Search AU/NZ legislation with the same method/jurisdiction/sort controls.                                                     |
-| `fetch_document_text` | Fetch full text from an AustLII or jade.io URL (HTML, PDF with OCR fallback, jade.io via GWT-RPC).                            |
+| `fetch_document_text` | Fetch full text from an AustLII or jade.io URL (HTML, PDF, jade.io via GWT-RPC).                                              |
 
 ### Citation + bibliography (AGLC4)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,11 +24,12 @@ We will respond within 48 hours and provide updates as the issue is addressed.
 ## Security Considerations
 
 This tool:
+
 - Makes HTTP requests to AustLII and jade.io
 - Does not store user data
 - Does not require authentication
 - Runs locally as an MCP server
-- Uses OCR for PDF processing (requires Tesseract)
+- Extracts digital text from PDFs via pdf-parse (no OCR)
 
 ### For Users
 
@@ -49,6 +50,7 @@ This tool:
 ### Dependency Vulnerabilities
 
 We monitor dependencies for vulnerabilities using:
+
 - `npm audit`
 - Dependabot alerts
 - Regular dependency updates
@@ -56,24 +58,20 @@ We monitor dependencies for vulnerabilities using:
 ### External API Calls
 
 This tool makes requests to:
+
 - AustLII (public legal database)
 - jade.io (if user provides URLs)
 
 Users should:
+
 - Respect terms of service of these platforms
 - Implement rate limiting in production use
 - Not expose this tool to untrusted input sources
 
-### OCR Processing
-
-When processing PDFs with OCR:
-- Temporary files are created in system temp directory
-- Files are cleaned up after processing
-- Tesseract runs locally (no data sent externally)
-
 ## Security Updates
 
 Security updates are released as soon as possible after a vulnerability is confirmed. Users should:
+
 - Subscribe to GitHub releases
 - Monitor npm advisories
 - Update promptly when security releases are published

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -162,7 +162,6 @@
 {
   "text": "Full judgment text...",
   "citations": ["[1992] HCA 23"],
-  "ocrUsed": false,
   "paragraphs": ["[1] ...", "[2] ..."]
 }
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,46 +11,32 @@ jurisd is a Model Context Protocol (MCP) server for Australian and New Zealand l
 
 **Key Features:**
 
-- Dual-source search (AustLII + jade.io)
-- OCR-capable PDF extraction
+- AustLII case + legislation search, with jade.io citation enhancement
+- Digital PDF text extraction (pdf-parse)
 - AGLC4 citation formatting
-- jade.io citator integration
+- jade.io citator integration (runtime)
 
 ---
 
 ## System Architecture
 
-```
-┌─────────────────────────────────────────┐
-│ MCP Clients (Claude Code, Cursor, etc.) │
-└─────────────────────────────────────────┘
-                    │
-                    ▼
-┌──────────────────────────────────────────────┐
-│ jurisd Server (15 Tools)                       │
-│ ┌──────────────────────────────────────────┐  │
-│ │ Live + citation (10):                     │  │
-│ │  search_cases, search_legislation,        │  │
-│ │  fetch_document_text, format_citation,    │  │
-│ │  resolve_citation, jade_lookup,           │  │
-│ │  search_citing_cases, cite,               │  │
-│ │  bibliography, cache_cited_by             │  │
-│ ├──────────────────────────────────────────┤  │
-│ │ Local data-module recall (5, offline):    │  │
-│ │  get_provision, get_act_structure,        │  │
-│ │  find_citing, semantic_search_local,      │  │
-│ │  list_data_modules                        │  │
-│ └──────────────────────────────────────────┘  │
-└──────────────────────────────────────────────┘
-        │            │              │
-        ▼            ▼              ▼
-   ┌─────────┐  ┌─────────┐  ┌──────────────────┐
-   │ Live    │  │ Local   │  │ Domain adapter   │
-   │ sources │  │ data    │  │ slot (optional)  │
-   │ AustLII │  │ modules │  │ baseline ↔       │
-   │ jade.io │  │ (DuckDB │  │ domain-special-  │
-   │         │  │ parquet)│  │ ised, BYOK       │
-   └─────────┘  └─────────┘  └──────────────────┘
+```mermaid
+flowchart TD
+    Clients["MCP Clients (Claude Code, Cursor, etc.)"]
+
+    subgraph Server["jurisd Server (15 tools)"]
+        Live["Live + citation (10):<br/>search_cases, search_legislation, fetch_document_text,<br/>format_citation, resolve_citation, jade_lookup,<br/>search_citing_cases, cite, bibliography, cache_cited_by"]
+        Local["Local data-module recall (5, offline):<br/>get_provision, get_act_structure, find_citing,<br/>semantic_search_local, list_data_modules"]
+    end
+
+    LiveSrc["Live sources:<br/>AustLII (primary search),<br/>jade.io (runtime citation enhancement)"]
+    Modules["Local data modules<br/>(DuckDB over parquet)"]
+    Adapter["Domain-adapter slot (optional):<br/>baseline vs domain-specialised, BYOK"]
+
+    Clients --> Server
+    Live --> LiveSrc
+    Local --> Modules
+    Local --> Adapter
 ```
 
 The domain-adapter slot is **vendor-neutral**: the baseline adapter (pure local
@@ -70,9 +56,9 @@ The distinction is capability presence, never a paid/free tier.
 Live + citation (10):
 | Tool | Description |
 |------|-------------|
-| search_cases | Dual AustLII + jade.io case search |
+| search_cases | AustLII case search, cross-referenced with jade.io citation data |
 | search_legislation | AustLII legislation search |
-| fetch_document_text | Full-text retrieval (HTML/PDF/OCR) |
+| fetch_document_text | Full-text retrieval (HTML/PDF) |
 | format_citation | AGLC4 formatting: `mode: full\|short\|ibid\|subsequent\|pinpoint` |
 | resolve_citation | Citation resolution: `mode: auto\|validate\|search` |
 | jade_lookup | jade.io lookup: `by: article_id\|citation` |
@@ -96,16 +82,17 @@ Local data-module recall (5; offline, closed-world over installed modules):
 - Authority-based ranking (HCA > FCAFC > FCA > state courts)
 - Rate limiting: 10 req/min
 
-### 3. jade.io Service
+### 3. jade.io Service (runtime citation enhancement)
 
 - GWT-RPC reverse-engineering
-- Protocols: proposeCitables (search), avd2Request (fetch), LeftoverRemoteService (citator)
+- Protocols: proposeCitables (citable lookup), avd2Request (fetch), LeftoverRemoteService (citator)
+- Cross-references jade.io citation data into live results; AustLII remains the primary search backend
 - Rate limiting: 5 req/min
 
 ### 4. Document Fetcher
 
 - HTML: Cheerio parse
-- PDF: pdf-parse + Tesseract OCR fallback
+- PDF: pdf-parse (digital text only)
 - Extracts paragraphs for pinpoint citations
 
 ### 5. Citation Service
@@ -165,7 +152,6 @@ MCP_TRANSPORT=http npm start
 | ------------------- | ----------------- | --------------------------------------------- |
 | AUSTLII_SEARCH_BASE | AustLII URL       | Search endpoint                               |
 | AUSTLII_TIMEOUT     | 60000             | Request timeout (ms)                          |
-| OCR_LANGUAGE        | eng               | Tesseract language                            |
 | JADE_SESSION_COOKIE | —                 | jade.io auth cookie                           |
 | MCP_TRANSPORT       | stdio             | stdio or http                                 |
 | ISAACUS_API_KEY     | —                 | BYOK key for the optional domain-adapter slot |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -107,11 +107,11 @@ both work. Set them only to enable the feature each one gates.
 
 ### Authentication / BYOK
 
-| Variable              | Enables                                                                                              |
-| --------------------- | ---------------------------------------------------------------------------------------------------- |
-| `JADE_SESSION_COOKIE` | jade.io authenticated search, full-text fetch, and the citator. Your own subscription cookie.        |
-| `ISAACUS_API_KEY`     | The optional **domain-specialised** adapter slot (rerank + extractive-QA) over local results (BYOK). |
-| `ISAACUS_BASE_URL`    | Override the domain-adapter endpoint (optional; defaults to the provider's base URL).                |
+| Variable              | Enables                                                                                                                                      |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `JADE_SESSION_COOKIE` | jade.io citation/article resolution, the citator (citing-cases), and authenticated full-text fetch at runtime. Your own subscription cookie. |
+| `ISAACUS_API_KEY`     | The optional **domain-specialised** adapter slot (rerank + extractive-QA) over local results (BYOK).                                         |
+| `ISAACUS_BASE_URL`    | Override the domain-adapter endpoint (optional; defaults to the provider's base URL).                                                        |
 
 **`JADE_SESSION_COOKIE`** — log in to jade.io in your browser, open DevTools →
 Network, navigate to any article, copy the full `Cookie` request header value
@@ -142,7 +142,7 @@ distinction is capability presence, framed as baseline vs domain-specialised.
 | `JURISD_MODELS_DIR`            | `~/.jurisd/models`  | Cache dir for the local embedding model.                                                                           |
 | `JURISD_EMBED_OFFLINE`         | `false`             | Hard-fail rather than reach the network for the embedding model (air-gapped installs must pre-seed the model dir). |
 
-### Live layer / OCR / search defaults
+### Live layer / search defaults
 
 | Variable                | Effect                                                 |
 | ----------------------- | ------------------------------------------------------ |
@@ -151,8 +151,6 @@ distinction is capability presence, framed as baseline vs domain-specialised.
 | `AUSTLII_REFERER`       | Referer header.                                        |
 | `AUSTLII_USER_AGENT`    | User-agent string.                                     |
 | `AUSTLII_TIMEOUT`       | Request timeout (ms).                                  |
-| `OCR_LANGUAGE`          | Tesseract OCR language (default `eng`).                |
-| `OCR_OEM`, `OCR_PSM`    | OCR engine + page-segmentation modes.                  |
 | `DEFAULT_SEARCH_LIMIT`  | Default search results (default 10).                   |
 | `MAX_SEARCH_LIMIT`      | Maximum search results (default 50).                   |
 | `DEFAULT_OUTPUT_FORMAT` | Default format: `json` / `text` / `markdown` / `html`. |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -297,7 +297,7 @@ function calculateAuthorityScore(result: SearchResult): number {
 3. ✅ `decodeGwtInt(encoded)` - inverse of existing `encodeGwtInt` for article ID decoding
 4. ✅ `parseProposeCitablesResponse(text)` - extracts case names, neutral + reported citations, and jade article IDs from "document in Jade" descriptor anchors in the string table
 5. ✅ `searchJade(query, options)` - replaces placeholder, calls `proposeCitables` via POST to `/jadeService.do`
-6. ✅ `search_cases` MCP tool now runs AustLII and jade.io in parallel, deduplicates by neutral citation
+6. ✅ `search_cases` MCP tool merges jade.io citation data into AustLII case-search results at runtime, deduplicating by neutral citation
 7. ✅ Graceful degradation: returns `[]` when `JADE_SESSION_COOKIE` is unset (no error to caller)
 8. ✅ HAR fixture files for deterministic testing: `propose-citables-mabo.txt` (75KB) and `propose-citables-rice.txt`
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -103,9 +103,6 @@ All configuration is managed through the ConfigMap (`k8s/configmap.yaml`). To mo
 | `JADE_BASE_URL`         | `https://jade.io`                                 | jade.io base URL             |
 | `JADE_USER_AGENT`       | `jurisd/0.1.0 (legal research tool)`              | jade.io user agent           |
 | `JADE_TIMEOUT`          | `15000`                                           | jade.io request timeout (ms) |
-| `OCR_LANGUAGE`          | `eng`                                             | Tesseract OCR language       |
-| `OCR_OEM`               | `1`                                               | OCR Engine Mode              |
-| `OCR_PSM`               | `3`                                               | Page Segmentation Mode       |
 | `DEFAULT_SEARCH_LIMIT`  | `10`                                              | Default search results       |
 | `MAX_SEARCH_LIMIT`      | `50`                                              | Maximum search results       |
 | `DEFAULT_OUTPUT_FORMAT` | `json`                                            | Default output format        |

--- a/skills/jurisd-research/SKILL.md
+++ b/skills/jurisd-research/SKILL.md
@@ -5,8 +5,8 @@ description: Expert Australian/NZ legal research and AGLC4 citation using the ju
 
 # jurisd: Australian/NZ legal research
 
-jurisd is an MCP server for AU/NZ legal research. It searches AustLII and jade.io,
-fetches full-text judgments (with OCR fallback), formats AGLC4 citations, manages a
+jurisd is an MCP server for AU/NZ legal research. It searches AustLII (with jade.io
+citation enhancement at runtime), fetches full-text judgments, formats AGLC4 citations, manages a
 local citation cache + bibliography, and serves offline recall from installed data
 modules. There are **15 tools**; operation variants are picked via a
 `mode`/`op`/`action`/`by` discriminator, not separate tools.
@@ -33,12 +33,12 @@ with module name, version, and snapshot date; mind the staleness advisory.
 
 ### Live research
 
-- **`search_cases`** — NL case-law search across all AU/NZ jurisdictions (AustLII +
-  jade.io merged, authority-ranked). `method`: auto/title/phrase/all/any/near/boolean;
+- **`search_cases`** — NL case-law search across all AU/NZ jurisdictions (AustLII,
+  authority-ranked; jade.io citation data cross-referenced into results at runtime). `method`: auto/title/phrase/all/any/near/boolean;
   `jurisdiction`; `sortBy` auto/relevance/date; `offset` for pagination.
 - **`search_legislation`** — same controls for legislation (`method` adds `legis`).
-- **`fetch_document_text`** — full text from an AustLII or jade.io URL (HTML, PDF+OCR,
-  jade.io GWT-RPC). Pass `citeKey` to also save a local source copy + freshness headers.
+- **`fetch_document_text`** — full text from an AustLII or jade.io URL (HTML, PDF via
+  pdf-parse, jade.io GWT-RPC). Pass `citeKey` to also save a local source copy + freshness headers.
 
 ### Citation + bibliography (AGLC4)
 


### PR DESCRIPTION
## Summary

Documentation-only cleanup reflecting two product facts.

- **OCR removed.** Tesseract/OCR was removed from the product (#111); `fetch_document_text` now extracts digital PDF text via `pdf-parse` only. Dropped all current-state OCR mentions, the `OCR_*` env vars (k8s/README, INSTALL, ARCHITECTURE), the `node-tesseract-ocr` third-party-licence entry, and the stale `ocrUsed` output field in AGENT-GUIDE.
- **jade.io reframed.** jade.io is now positioned as a *runtime citation-enhancement* layer (citator, citation/article resolution, result cross-referencing) rather than a co-equal "dual search engine". AustLII remains the primary search backend. Touches README, ARCHITECTURE, INSTALL, ROADMAP, SKILL.md, CONTRIBUTING.
- **Mermaid diagram.** Converted the ASCII architecture diagram in `docs/ARCHITECTURE.md` to a Mermaid `flowchart` (validated end-to-end: renders to SVG via Chrome).

CHANGELOG released history (the `[0.1.0]` section) is intentionally left untouched; the OCR removal is already recorded under `[Unreleased]`.

## How it was reviewed

Reviewed with a reusable, dynamic doc-review workflow (discover doc files -> per-file reviewer vs ground-truth assertions -> adversarial verifier per finding):

- **Pass 1:** 33 findings confirmed across 13 files (the verifiers correctly excluded released CHANGELOG history and the `[Unreleased]` removal note).
- Edits applied, then **Pass 2: 0 findings across 13 files.**

## Note for review (jade.io scope)

The code still runs `searchJade()` inside `search_cases` and merges results (dedup by neutral citation, with graceful AustLII-only fallback). Rather than delete that, I framed it as "jade.io citation data cross-referenced into AustLII results at runtime" so the docs stay accurate while honouring the citation-enhancement positioning. If you'd prefer the search-merge described differently, or dropped from the docs entirely, say so and I'll adjust.

## Signing

The commit is SSH-signed with the Claude key (`claudecode@anthropic.com`) and verifies locally as a good signature. 
