### PR TITLE
fix(jade): refresh stale GWT strong names and permutation

### DIFF
--- a/src/services/jade-gwt.ts
+++ b/src/services/jade-gwt.ts
@@ -67,33 +67,33 @@ export const JADE_MODULE_BASE = "https://jade.io/au.com.barnet.jade.JadeClient/"
  * This may change when jade.io redeploys the GWT app.
  * If content fetching returns an exception response, this hash may need refreshing
  * by inspecting the X-GWT-Permutation header in a fresh browser session.
- * Last verified: 2026-05-02.
+ * Last verified: 2026-06-13.
  */
-export const JADE_STRONG_NAME = "78A4E1BF92432B956B45BFCCAAD8EA7F";
+export const JADE_STRONG_NAME = "F6E610452C7A15DE693DC8F95CF6849C";
 
 /**
  * GWT-RPC strong name (type hash) for ArticleViewRemoteService.
  * This service handles article content loading via the avd2Request method.
- * Discovered via SPA navigation interception (2026-03-02). Last verified: 2026-05-02.
+ * Discovered via SPA navigation interception (2026-03-02). Last verified: 2026-06-13.
  */
-export const AVD2_STRONG_NAME = "540FEEFE1755510EEA65022BF9AEE249";
+export const AVD2_STRONG_NAME = "140B3EF36354F0C5A95299A70B18A25F";
 
 /**
  * GWT permutation identifier for the Chrome/macOS compiled JS bundle.
  * Sent in the X-GWT-Permutation request header.
  * Different from JADE_STRONG_NAME - this identifies the browser-specific
  * JavaScript permutation, not the serialisation type hash.
- * Last verified: 2026-03-03.
+ * Last verified: 2026-06-13.
  */
-export const JADE_PERMUTATION = "FEBDA911A95AD2DF02425A9C60379101";
+export const JADE_PERMUTATION = "9F7FA3DEE1E002939D47FA3D6C3F3DA1";
 
 /**
  * GWT-RPC strong name (type hash) for LeftoverRemoteService.
  * This service handles citation-context searches ("who cites this article")
  * and citation data retrieval. NOT used for freetext case search.
- * Discovered from HAR analysis (2026-03-03). Last verified: 2026-05-02.
+ * Discovered from HAR analysis (2026-03-03). Last verified: 2026-06-13.
  */
-export const LEFTOVER_STRONG_NAME = "1D24CC41B607715BFC2FAE9A28012C5F";
+export const LEFTOVER_STRONG_NAME = "C759183224A415CB53405469AC1B351C";
 
 /**
  * Encodes a non-negative integer using GWT's custom base-64 charset.

--- a/src/test/unit/jade-gwt.test.ts
+++ b/src/test/unit/jade-gwt.test.ts
@@ -65,7 +65,7 @@ describe("buildGetInitialContentRequest", () => {
   it("produces the exact known POST body for article 67401", () => {
     // Captured verbatim from Proxyman HAR export (jade.io_03-02-2026-13-48-33.har)
     const expected =
-      "7|0|7|https://jade.io/au.com.barnet.jade.JadeClient/|78A4E1BF92432B956B45BFCCAAD8EA7F|" +
+      "7|0|7|https://jade.io/au.com.barnet.jade.JadeClient/|F6E610452C7A15DE693DC8F95CF6849C|" +
       "au.com.barnet.jade.cs.remote.JadeRemoteService|getInitialContent|" +
       "au.com.barnet.jade.cs.persistent.Jrl/728826604|au.com.barnet.jade.cs.persistent.Article|" +
       "java.util.ArrayList/4159755760|1|2|3|4|1|5|5|QdJ|A|0|A|A|6|0|";
@@ -88,7 +88,7 @@ describe("buildGetMetadataRequest", () => {
   it("produces the exact known POST body for article 67401", () => {
     // Captured verbatim from Proxyman HAR export
     const expected =
-      "7|0|5|https://jade.io/au.com.barnet.jade.JadeClient/|78A4E1BF92432B956B45BFCCAAD8EA7F|" +
+      "7|0|5|https://jade.io/au.com.barnet.jade.JadeClient/|F6E610452C7A15DE693DC8F95CF6849C|" +
       "au.com.barnet.jade.cs.remote.JadeRemoteService|getArticleStructuredMetadata|J|" +
       "1|2|3|4|1|5|QdJ|";
     expect(buildGetMetadataRequest(67401)).toBe(expected);
@@ -107,7 +107,7 @@ describe("buildAvd2Request", () => {
     // Article: AA v The Trustees of the Roman Catholic Church... [2026] HCA 2
     const expected =
       "7|0|10|https://jade.io/au.com.barnet.jade.JadeClient/|" +
-      "540FEEFE1755510EEA65022BF9AEE249|" +
+      "140B3EF36354F0C5A95299A70B18A25F|" +
       "au.com.barnet.jade.cs.remote.ArticleViewRemoteService|avd2Request|" +
       "au.com.barnet.jade.cs.csobjects.avd.Avd2Request/2858816011|" +
       "au.com.barnet.jade.cs.persistent.Jrl/728826604|" +
@@ -227,7 +227,7 @@ describe("buildProposeCitablesRequest", () => {
     // Captured verbatim from jade.io_03-03-2026-10-08-59.har, entry 11
     const expected =
       "7|0|10|https://jade.io/au.com.barnet.jade.JadeClient/|" +
-      "78A4E1BF92432B956B45BFCCAAD8EA7F|" +
+      "F6E610452C7A15DE693DC8F95CF6849C|" +
       "au.com.barnet.jade.cs.remote.JadeRemoteService|proposeCitables|" +
       "java.lang.String/2004016611|" +
       "au.com.barnet.jade.cs.csobjects.qsearch.QuickSearchFlags/2740681188|" +
@@ -565,7 +565,7 @@ describe("parseCitatorResponse", () => {
 describe("buildCitatorSearchRequest", () => {
   it("uses LeftoverRemoteService strong name", () => {
     const body = buildCitatorSearchRequest(2463606);
-    expect(body).toContain("1D24CC41B607715BFC2FAE9A28012C5F");
+    expect(body).toContain("C759183224A415CB53405469AC1B351C");
     expect(body).toContain("LeftoverRemoteService");
   });
 

--- a/src/test/unit/recall-tools-shapes.test.ts
+++ b/src/test/unit/recall-tools-shapes.test.ts
@@ -13,7 +13,11 @@ import {
   semanticSearchLocal,
   listDataModules,
 } from "../../services/modules.js";
-import { setQueryEmbedderForTest, resetEmbedder, isEmbedderAvailable } from "../../services/embedder.js";
+import {
+  setQueryEmbedderForTest,
+  resetEmbedder,
+  isEmbedderAvailable,
+} from "../../services/embedder.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES = path.join(__dirname, "../fixtures/modules");


### PR DESCRIPTION
## Summary

jade.io redeployed its GWT application and rotated its per-service serialization-policy strong names and the compiled-JS permutation. All four constants in `src/services/jade-gwt.ts` (`JADE_STRONG_NAME`, `AVD2_STRONG_NAME`, `LEFTOVER_STRONG_NAME`, `JADE_PERMUTATION`) were stale.

Effect: live citation tooling was broken — `search_citing_cases` returned `totalCount: 0`, and article/citator calls would draw `//EX` serialization exceptions.

## Fix

Refreshed all four constants to the current jade deployment's values. The parser and `totalCount` heuristic were already correct; only the constants were stale.

Each refreshed value was replay-validated end-to-end against the live service:
- `proposeCitables` -> `//OK`
- `avd2Request` (article view) -> `//OK`, full article HTML
- `LeftoverRemoteService` citator -> `//OK`; Mabo `[1992] HCA 23` resolves `totalCount` **703** (was 695), 27 citing-case citations parsed per page

Wire-format regression pins in `src/test/unit/jade-gwt.test.ts` updated to match.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` jade suites: 137 passed
- [x] Live replay of proposeCitables / avd2 / citator: all `//OK`