### PR TITLE
security: path-traversal, SSRF, redirect & CI/k8s hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,9 +33,21 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-        
+
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    reviewers:
+      - "russellbrenner"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
+  # Keep the Dockerfile base-image digest pin current.
+  - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,11 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+# Least-privilege default for the whole workflow; the build job widens only to
+# packages:write for the GHCR push.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -23,13 +28,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -37,7 +42,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -45,7 +50,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
   schedule:
     # Run daily at 2am UTC to catch AustLII changes
-    - cron: '0 2 * * *'
+    - cron: "0 2 * * *"
   workflow_dispatch:
 
 permissions:
@@ -19,23 +19,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20.x'
-          cache: 'npm'
-      
+          node-version: "20.x"
+          cache: "npm"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Run ESLint
         run: npm run lint
-      
+
       - name: Check formatting
         run: npm run format:check
-      
+
       - name: Check TypeScript types
         run: npx tsc --noEmit
 
@@ -46,32 +46,32 @@ jobs:
     strategy:
       matrix:
         node-version: [20.x, 22.x]
-    
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-      
+          cache: "npm"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Build TypeScript
         run: npm run build
-      
+
       - name: Run tests
         run: npm test
         env:
           CI: true
           VITEST_POOL_TIMEOUT: 60000
-      
+
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: test-results-node-${{ matrix.node-version }}
           path: |
@@ -84,21 +84,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20.x'
-          cache: 'npm'
-      
+          node-version: "20.x"
+          cache: "npm"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Run npm audit
         run: npm audit --audit-level=moderate
         continue-on-error: true
-      
+
       - name: Check for security vulnerabilities
         run: |
           if npm audit --audit-level=high --json | jq -e '.metadata.vulnerabilities.high > 0 or .metadata.vulnerabilities.critical > 0'; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20.x"
           cache: "npm"
@@ -37,8 +37,11 @@ jobs:
 
       - name: Extract release notes from CHANGELOG
         id: changelog
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
-          VERSION="${{ steps.version.outputs.VERSION }}"
+          # VERSION is bound via env (above) rather than interpolated into the
+          # shell, so a crafted tag name cannot break out of the string.
           # Extract section for this version from CHANGELOG.md: everything between
           # ## [VERSION] and the next section heading or the trailing link-definition block
           NOTES=$(awk -v ver="$VERSION" '$0 ~ "^## \\["ver"\\]" {flag=1; next} /^## \[|^\[Unreleased\]:/ {flag=0} flag' CHANGELOG.md)
@@ -51,7 +54,7 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           body: ${{ steps.changelog.outputs.NOTES }}
           draft: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@
 # prebuilt artefact for the build arch directly.
 
 # ── Stage 1: build the TypeScript ──────────────────────────────────────────
-FROM node:20-bookworm-slim AS builder
+# Base image pinned by multi-arch manifest digest (supply-chain: an immutable
+# base, not a mutable tag). Update the digest with the tag when bumping Node.
+FROM node:20-bookworm-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0 AS builder
 
 WORKDIR /app
 
@@ -30,7 +32,7 @@ COPY src ./src
 RUN npm run build
 
 # ── Stage 2: slim runtime ──────────────────────────────────────────────────
-FROM node:20-bookworm-slim AS runtime
+FROM node:20-bookworm-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0 AS runtime
 
 WORKDIR /app
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 # Build and package script for jurisd
 # This script builds the Docker image and optionally exports it for k3s deployment
 
-set -e
+set -euo pipefail
 
 VERSION=${1:-latest}
 IMAGE_NAME="jurisd:${VERSION}"
@@ -23,7 +23,7 @@ echo ""
 read -p "Export image for k3s deployment? (y/n) " -n 1 -r
 echo ""
 
-if [[ $REPLY =~ ^[Yy]$ ]]; then
+if [[ ${REPLY:-} =~ ^[Yy]$ ]]; then
     echo "📦 Exporting image to ${EXPORT_TAR}..."
     docker save "${IMAGE_NAME}" -o "${EXPORT_TAR}"
     echo ""

--- a/deploy-k8s.sh
+++ b/deploy-k8s.sh
@@ -2,7 +2,7 @@
 # Deploy script for jurisd to k3s cluster
 # This script deploys or updates the jurisd service on a k3s cluster
 
-set -e
+set -euo pipefail
 
 ACTION=${1:-apply}
 NAMESPACE="jurisd"
@@ -46,6 +46,9 @@ echo "   ✓ Namespace created/updated"
 
 kubectl apply -f k8s/configmap.yaml
 echo "   ✓ ConfigMap created/updated"
+
+kubectl apply -f k8s/networkpolicy.yaml
+echo "   ✓ NetworkPolicy created/updated"
 
 kubectl apply -f k8s/deployment.yaml
 echo "   ✓ Deployment created/updated"

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -22,6 +22,11 @@ data:
   # Node Environment
   NODE_ENV: "production"
 
+  # Writable state dir on the read-only-rootfs pod. The citation cache (and its
+  # sources/ subdir) default to the process cwd (/app), which is read-only in
+  # the deployment; point them at the /data emptyDir mount instead.
+  AUSLAW_CACHE_DIR: "/data/cache"
+
   # Transport: http for k8s deployment, stdio for local MCP usage
   MCP_TRANSPORT: "http"
 

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -39,8 +39,14 @@ spec:
             value: "1"
       containers:
         - name: jurisd
+          # SECURITY: pin to an immutable digest in production. CI publishes an
+          # immutable ghcr.io/<owner>/jurisd:<git-sha> tag per build (see
+          # .github/workflows/docker.yml) alongside a floating :latest. Replace
+          # the tag below with @sha256:<digest> of the build you intend to run.
           image: ghcr.io/OWNER/jurisd:latest
-          imagePullPolicy: IfNotPresent
+          # Always re-pull while a floating tag is in use so a node cannot serve
+          # a stale or poisoned cached :latest (no effect once pinned by digest).
+          imagePullPolicy: Always
           ports:
             - containerPort: 3000
               name: http
@@ -52,6 +58,14 @@ spec:
               mountPath: /app/config.yaml
               subPath: config.yaml
               readOnly: true
+            # Writable scratch + state mounts so the container can run with a
+            # read-only root filesystem (securityContext below). /tmp holds
+            # fetch-module downloads + DuckDB scratch; /data holds installed
+            # modules and the citation cache (AUSLAW_CACHE_DIR=/data/cache).
+            - name: tmp
+              mountPath: /tmp
+            - name: data
+              mountPath: /data
           resources:
             requests:
               memory: "256Mi"
@@ -79,7 +93,9 @@ spec:
             runAsNonRoot: true
             runAsUser: 1001
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
             capabilities:
               drop:
                 - ALL
@@ -90,5 +106,11 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
+        - name: tmp
+          emptyDir: {}
+        - name: data
+          emptyDir: {}
       securityContext:
         fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault

--- a/k8s/networkpolicy.yaml
+++ b/k8s/networkpolicy.yaml
@@ -1,0 +1,61 @@
+---
+# Default-deny + least-privilege egress for the jurisd workload.
+#
+# jurisd's whole purpose is making OUTBOUND HTTP requests to legal sources
+# (AustLII, jade.io) with a TLS-impersonating client. Without a NetworkPolicy a
+# compromised pod (e.g. via a dependency parsing attacker-influenced fetched
+# content) has unrestricted egress to the internet AND to internal cluster
+# services / the cloud metadata endpoint — ideal for SSRF pivoting and exfil.
+#
+# This policy denies all ingress/egress by default, then allows only:
+#   - DNS resolution (kube-dns)
+#   - outbound HTTPS to public addresses, with private + link-local/metadata
+#     ranges explicitly excluded (network-layer SSRF backstop)
+#   - inbound to :3000 from the ingress controller
+#
+# NOTE: requires a NetworkPolicy-enforcing CNI (Calico, Cilium, etc.). Tighten
+# the ingress `namespaceSelector` to your actual ingress-controller namespace.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: jurisd-default-deny
+  namespace: jurisd
+  labels:
+    app.kubernetes.io/name: jurisd
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: jurisd
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Inbound to the HTTP port. Tighten `from` to the ingress-controller
+    # namespace (e.g. namespaceSelector matchLabels kubernetes.io/metadata.name: traefik).
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    # DNS (kube-dns / CoreDNS).
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Outbound HTTPS to public hosts only. Private RFC1918, CGNAT, and
+    # link-local/metadata (169.254.0.0/16, incl. 169.254.169.254) are excluded
+    # so a compromised pod cannot reach internal services or cloud metadata.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 169.254.0.0/16
+              - 100.64.0.0/10
+      ports:
+        - protocol: TCP
+          port: 443

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "node": ">=20.18.1"
       },
       "optionalDependencies": {
-        "impit": "^0.14.1"
+        "impit": "0.14.1"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "format:check": "prettier --check \"src/**/*.ts\"",
     "docs": "typedoc",
     "docs:serve": "npx serve docs/api",
-    "prepare": "(husky || exit 0) && node -e \"const p=require('path'),cp=require('child_process');if(process.env.INIT_CWD&&p.resolve(process.env.INIT_CWD)!==process.cwd())cp.execSync('npm run build',{stdio:'inherit'})\""
+    "prepare": "node -e \"if(require('fs').existsSync('.git'))require('child_process').execSync('husky',{stdio:'inherit'})\""
   },
   "keywords": [
     "model-context-protocol",
@@ -88,6 +88,6 @@
     ]
   },
   "optionalDependencies": {
-    "impit": "^0.14.1"
+    "impit": "0.14.1"
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -88,8 +88,14 @@ export const DEFAULT_TIMEOUT_MS = 30_000;
 /** Extended timeout for slow endpoints */
 export const LONG_TIMEOUT_MS = 60_000;
 
-/** Maximum document size we will attempt to download (50 MB) */
-export const MAX_CONTENT_LENGTH = 50 * 1024 * 1024;
+/**
+ * Maximum document size we will attempt to download (10 MB).
+ *
+ * Legal documents (HTML/PDF) are well under this; a smaller cap bounds the
+ * CPU/memory a single hostile or oversized response can cost during cheerio DOM
+ * construction + per-node parsing (DoS hardening).
+ */
+export const MAX_CONTENT_LENGTH = 10 * 1024 * 1024;
 
 /** Maximum number of jade.io articles to resolve concurrently during search */
 export const MAX_JADE_RESOLUTIONS = 5;

--- a/src/data/manifest.schema.json
+++ b/src/data/manifest.schema.json
@@ -165,8 +165,10 @@
         "properties": {
           "path": {
             "type": "string",
-            "description": "Path relative to base_uri.",
-            "minLength": 1
+            "description": "Path relative to base_uri. Must be a safe relative path: alphanumeric-led segments separated by '/', no '..' traversal, no absolute paths.",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*(?:/[A-Za-z0-9][A-Za-z0-9._-]*)*$"
           },
           "sha256": {
             "type": "string",

--- a/src/data/manifest.ts
+++ b/src/data/manifest.ts
@@ -9,6 +9,7 @@
  */
 
 import { createRequire } from "node:module";
+import path from "node:path";
 
 const require = createRequire(import.meta.url);
 
@@ -81,6 +82,43 @@ export const IMPLEMENTED_SCHEMA_VERSION = 1;
 /** Module names must be safe SQL identifiers and safe path segments. */
 export const MODULE_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
+/**
+ * A `files[].path` must be a safe relative path: one or more dot/dash/underscore
+ * segments separated by `/`, each segment starting with an alphanumeric. This
+ * forbids absolute paths, `..` traversal, leading slashes, backslashes, and NUL —
+ * the manifest is fetched from a remote (Hugging Face) and an unconstrained path
+ * is a zip-slip-equivalent arbitrary-file-write/read vector (see
+ * `fetchModule`/`verifyModule`).
+ */
+export const SAFE_MODULE_FILE_PATH =
+  /^[A-Za-z0-9][A-Za-z0-9._-]*(?:\/[A-Za-z0-9][A-Za-z0-9._-]*)*$/;
+
+/** True when `p` is a safe relative module file path (see {@link SAFE_MODULE_FILE_PATH}). */
+export function isSafeModuleFilePath(p: unknown): p is string {
+  if (typeof p !== "string" || p.length === 0 || p.length > 255) return false;
+  if (p.includes("\0") || p.includes("..") || p.includes("\\")) return false;
+  if (path.isAbsolute(p)) return false;
+  return SAFE_MODULE_FILE_PATH.test(p);
+}
+
+/** Keys whose presence in a parsed manifest indicates a prototype-pollution attempt. */
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+/**
+ * Recursively detect a `__proto__`/`constructor`/`prototype` key in a parsed
+ * (remote) manifest object. `JSON.parse` materialises these as own enumerable
+ * properties, so `Object.entries` sees them; reject rather than risk a later
+ * merge/spread polluting `Object.prototype`.
+ */
+function hasDangerousKey(value: unknown, depth = 0): boolean {
+  if (depth > 8 || value === null || typeof value !== "object") return false;
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (DANGEROUS_KEYS.has(k)) return true;
+    if (hasDangerousKey(v, depth + 1)) return true;
+  }
+  return false;
+}
+
 let _schema: object | null = null;
 
 function loadSchema(): object {
@@ -140,6 +178,12 @@ function structuralValidate(data: unknown): ValidationResult {
     return { valid: false, error: "(root) manifest must be an object" };
   }
   const m = data as Record<string, unknown>;
+  if (hasDangerousKey(m)) {
+    return {
+      valid: false,
+      error: "manifest contains a forbidden key (__proto__/constructor/prototype)",
+    };
+  }
   const requireString = (k: string): string | undefined =>
     typeof m[k] === "string" && (m[k] as string).length > 0
       ? undefined
@@ -148,6 +192,17 @@ function structuralValidate(data: unknown): ValidationResult {
   for (const k of ["name", "module_version", "base_uri"]) {
     const err = requireString(k);
     if (err) return { valid: false, error: err };
+  }
+  // base_uri resolves files[].path; it must be an absolute HTTPS URL so a hostile
+  // manifest cannot point asset fetches at file:/data:/javascript: or plain HTTP.
+  let baseUrl: URL;
+  try {
+    baseUrl = new URL(m.base_uri as string);
+  } catch {
+    return { valid: false, error: "base_uri must be a valid absolute URL" };
+  }
+  if (baseUrl.protocol !== "https:") {
+    return { valid: false, error: `base_uri must use https (got ${baseUrl.protocol})` };
   }
   if (typeof m.schema_version !== "number" || !Number.isInteger(m.schema_version)) {
     return { valid: false, error: "schema_version must be an integer" };
@@ -172,6 +227,12 @@ function structuralValidate(data: unknown): ValidationResult {
     const file = f as Record<string, unknown>;
     if (typeof file.path !== "string" || typeof file.sha256 !== "string") {
       return { valid: false, error: "files[].path and files[].sha256 are required" };
+    }
+    if (!isSafeModuleFilePath(file.path)) {
+      return {
+        valid: false,
+        error: `files[].path '${String(file.path)}' is not a safe relative path`,
+      };
     }
     if (!/^[a-f0-9]{64}$/.test(file.sha256)) {
       return { valid: false, error: `files[].sha256 must be lowercase hex sha256 (${file.path})` };

--- a/src/server.ts
+++ b/src/server.ts
@@ -870,7 +870,7 @@ export function createMcpServer(): McpServer {
       .string()
       .optional()
       .describe(
-        "Write the .bib file to this absolute path (op=export). Defaults to <cacheDir>/<projectName>.bib",
+        "Write the .bib file to this path (op=export). Relative to the cache dir, or an absolute path that resolves within it; must end in .bib. Defaults to <cacheDir>/<projectName>.bib",
       ),
   };
   const bibliographyParser = z.object(bibliographyShape).superRefine((d, ctx) => {
@@ -934,7 +934,18 @@ export function createMcpServer(): McpServer {
           AUSLAW_CACHE_DIR_NAME,
           `${config.cache.projectName}.bib`,
         );
-        const writePath = input.outputPath ?? defaultPath;
+        // Confine the (caller-supplied) outputPath to the cache directory so a
+        // malicious/prompt-injected MCP client cannot write bib text to an
+        // arbitrary location (e.g. an autostart dir or a config file).
+        const cacheRoot = path.resolve(config.cache.dir);
+        const writePath = path.resolve(cacheRoot, input.outputPath ?? defaultPath);
+        const relToCache = path.relative(cacheRoot, writePath);
+        if (relToCache.startsWith("..") || path.isAbsolute(relToCache)) {
+          throw new Error("outputPath must resolve within the cache directory");
+        }
+        if (!writePath.endsWith(".bib")) {
+          throw new Error("outputPath must end in .bib");
+        }
 
         const { promises: fs } = await import("node:fs");
         await fs.mkdir(path.dirname(writePath), { recursive: true });

--- a/src/services/fetch-module.ts
+++ b/src/services/fetch-module.ts
@@ -27,8 +27,63 @@ import {
   type Manifest,
   IMPLEMENTED_SCHEMA_VERSION,
   MODULE_NAME_PATTERN,
+  isSafeModuleFilePath,
   validateManifest,
 } from "../data/manifest.js";
+
+/**
+ * Hosts a module manifest and its parquet assets may be fetched from. Modules
+ * are published as Hugging Face datasets; large files are served via a 302 to
+ * the HF LFS CDN (`cdn-lfs*.huggingface.co` / `*.hf.co`), so the allowlist is
+ * the HF domain families. This is the SSRF guard for the module-fetch path:
+ * neither an operator-supplied `--manifest-url` nor a hostile manifest
+ * `base_uri` may point fetches at internal/metadata addresses.
+ */
+const MODULE_ALLOWED_HOSTS = new Set(["huggingface.co", "hf.co"]);
+const MODULE_ALLOWED_HOST_SUFFIXES = [".huggingface.co", ".hf.co"];
+/** Bounded redirect chain for module asset fetches (HF resolve -> LFS CDN). */
+const MODULE_MAX_REDIRECTS = 5;
+
+/** Assert a module URL is HTTPS on an allowed Hugging Face host. Throws otherwise. */
+export function assertModuleUrl(raw: string): void {
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    throw new Error(`invalid module URL: ${raw}`);
+  }
+  if (u.protocol !== "https:") {
+    throw new Error(`module URL must use https (got ${u.protocol}): ${raw}`);
+  }
+  const host = u.hostname.toLowerCase();
+  const allowed =
+    MODULE_ALLOWED_HOSTS.has(host) || MODULE_ALLOWED_HOST_SUFFIXES.some((s) => host.endsWith(s));
+  if (!allowed) {
+    throw new Error(`module host '${host}' is not an allowed Hugging Face host`);
+  }
+}
+
+/**
+ * Fetch a module URL, re-validating the host on every redirect hop. Uses
+ * `redirect: "manual"` so an allowlisted HF URL cannot 302 us to an internal
+ * address (DNS-rebind / open-redirect SSRF); each hop must itself be an allowed
+ * HF host.
+ */
+async function secureModuleFetch(url: string): Promise<Response> {
+  let current = url;
+  for (let hop = 0; hop <= MODULE_MAX_REDIRECTS; hop++) {
+    assertModuleUrl(current);
+    const res = await fetch(current, { redirect: "manual" });
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get("location");
+      if (!location) return res;
+      current = new URL(location, current).toString();
+      continue;
+    }
+    return res;
+  }
+  throw new Error(`too many redirects while fetching ${url}`);
+}
 
 /** Result of a fetch or verify operation. */
 export interface FetchResult {
@@ -52,12 +107,12 @@ export interface FetchIO {
 /** The default IO backed by global fetch. */
 export const defaultIO: FetchIO = {
   async fetchBytes(url: string): Promise<Buffer> {
-    const res = await fetch(url);
+    const res = await secureModuleFetch(url);
     if (!res.ok) throw new Error(`GET ${url} -> HTTP ${res.status}`);
     return Buffer.from(await res.arrayBuffer());
   },
   async fetchJson(url: string): Promise<unknown> {
-    const res = await fetch(url);
+    const res = await secureModuleFetch(url);
     if (!res.ok) throw new Error(`GET ${url} -> HTTP ${res.status}`);
     return res.json();
   },
@@ -146,7 +201,16 @@ export async function fetchModule(
     // Persist the validated manifest alongside the parquet.
     fs.writeFileSync(path.join(tmpDir, "manifest.json"), JSON.stringify(manifest, null, 2) + "\n");
 
+    const tmpRoot = path.resolve(tmpDir);
     for (const file of manifest.files) {
+      // Defence-in-depth: validateManifest already rejects unsafe paths, but
+      // re-check at the write sink (the source-store.ts prefix-check pattern) so
+      // a path can never escape the temp dir even if validation is bypassed.
+      const destPath = path.resolve(tmpRoot, file.path);
+      if (!isSafeModuleFilePath(file.path) || !destPath.startsWith(tmpRoot + path.sep)) {
+        cleanup(tmpDir);
+        return { ok: false, name, error: `unsafe file path in manifest: ${file.path}` };
+      }
       const assetUrl = resolveAsset(manifest.base_uri, file.path);
       let bytes: Buffer;
       try {
@@ -170,7 +234,7 @@ export async function fetchModule(
             `Refusing to install a partially-verified module.`,
         };
       }
-      fs.writeFileSync(path.join(tmpDir, file.path), bytes);
+      fs.writeFileSync(destPath, bytes);
     }
 
     // 5. Atomic install: temp-then-rename so a half-written module never appears.
@@ -227,8 +291,12 @@ export function verifyModule(name: string, opts: { modulesDir?: string } = {}): 
   if (!validation.valid) {
     return { ok: false, name, error: `manifest failed schema validation: ${validation.error}` };
   }
+  const verifyRoot = path.resolve(dir);
   for (const file of manifest.files) {
-    const filePath = path.join(dir, file.path);
+    const filePath = path.resolve(verifyRoot, file.path);
+    if (!isSafeModuleFilePath(file.path) || !filePath.startsWith(verifyRoot + path.sep)) {
+      return { ok: false, name, error: `unsafe file path in manifest: ${file.path}` };
+    }
     if (!fs.existsSync(filePath)) {
       return { ok: false, name, error: `missing file ${file.path}` };
     }

--- a/src/services/fetcher.ts
+++ b/src/services/fetcher.ts
@@ -5,7 +5,7 @@ import { PDFParse } from "pdf-parse";
 import { config } from "../config.js";
 import { MAX_CONTENT_LENGTH } from "../constants.js";
 import { isJadeUrl, extractArticleId, fetchJadeArticleContent } from "./jade.js";
-import { assertFetchableUrl } from "../utils/url-guard.js";
+import { assertFetchableUrl, assertRedirectAllowed, MAX_REDIRECTS } from "../utils/url-guard.js";
 import { austliiRateLimiter, jadeRateLimiter } from "../utils/rate-limiter.js";
 import {
   isAustliiUrl,
@@ -403,6 +403,8 @@ export async function fetchDocumentText(url: string): Promise<FetchResponse> {
       headers,
       timeout: config.jade.timeout,
       maxContentLength: MAX_CONTENT_LENGTH,
+      maxRedirects: MAX_REDIRECTS,
+      beforeRedirect: assertRedirectAllowed,
     });
 
     const buffer = Buffer.from(response.data);

--- a/src/services/jade.ts
+++ b/src/services/jade.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import type { SearchResult, SearchOptions } from "./austlii.js";
 import { config } from "../config.js";
 import { jadeRateLimiter } from "../utils/rate-limiter.js";
+import { assertRedirectAllowed, MAX_REDIRECTS } from "../utils/url-guard.js";
 import {
   buildAvd2Request,
   parseAvd2Response,
@@ -218,6 +219,8 @@ export async function resolveArticle(articleId: number): Promise<JadeArticle> {
       timeout: config.jade.timeout,
       // jade.io pages can be substantial when authenticated
       maxContentLength: 5 * 1024 * 1024,
+      maxRedirects: MAX_REDIRECTS,
+      beforeRedirect: assertRedirectAllowed,
     });
 
     const html: string = typeof response.data === "string" ? response.data : String(response.data);
@@ -406,6 +409,8 @@ export async function searchJade(query: string, options: SearchOptions): Promise
       timeout: config.jade.timeout,
       responseType: "text",
       maxContentLength: 5 * 1024 * 1024,
+      maxRedirects: MAX_REDIRECTS,
+      beforeRedirect: assertRedirectAllowed,
     });
 
     const { results: parsed, flatArray } = parseProposeCitablesResponse(response.data as string);
@@ -506,6 +511,8 @@ export async function fetchJadeArticleContent(
     responseType: "text",
     // avd2Request responses can be large (700KB+ for HCA decisions)
     maxContentLength: 5 * 1024 * 1024,
+    maxRedirects: MAX_REDIRECTS,
+    beforeRedirect: assertRedirectAllowed,
   });
 
   return parseAvd2Response(response.data as string);
@@ -564,6 +571,8 @@ export async function searchCitingCases(caseName: string): Promise<CitatorSearch
       timeout: config.jade.timeout,
       responseType: "text",
       maxContentLength: 5 * 1024 * 1024,
+      maxRedirects: MAX_REDIRECTS,
+      beforeRedirect: assertRedirectAllowed,
     });
 
     const { flatArray } = parseProposeCitablesResponse(proposeResponse.data as string);
@@ -585,6 +594,8 @@ export async function searchCitingCases(caseName: string): Promise<CitatorSearch
       timeout: config.jade.timeout,
       responseType: "text",
       maxContentLength: 5 * 1024 * 1024,
+      maxRedirects: MAX_REDIRECTS,
+      beforeRedirect: assertRedirectAllowed,
     });
 
     const { results, totalCount } = parseCitatorResponse(citatorResponse.data as string);

--- a/src/services/source-store.ts
+++ b/src/services/source-store.ts
@@ -11,7 +11,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 import axios from "axios";
 import { fetchDocumentText } from "./fetcher.js";
-import { assertFetchableUrl } from "../utils/url-guard.js";
+import { assertFetchableUrl, assertRedirectAllowed, MAX_REDIRECTS } from "../utils/url-guard.js";
 
 export interface FreshnessResult {
   /** True when the server confirmed the local copy is current (HTTP 304). */
@@ -73,6 +73,8 @@ export async function checkSourceFreshness(
       headers,
       validateStatus: (s) => s === 200 || s === 304,
       timeout: 10_000,
+      maxRedirects: MAX_REDIRECTS,
+      beforeRedirect: assertRedirectAllowed,
     });
 
     return {
@@ -144,7 +146,11 @@ export async function storeSource(
   if (!etag && !lastModified) {
     try {
       assertFetchableUrl(url);
-      const headResp = await axios.head(url, { timeout: 10_000 });
+      const headResp = await axios.head(url, {
+        timeout: 10_000,
+        maxRedirects: MAX_REDIRECTS,
+        beforeRedirect: assertRedirectAllowed,
+      });
       etag = (headResp.headers["etag"] as string) ?? undefined;
       lastModified = (headResp.headers["last-modified"] as string) ?? undefined;
     } catch {

--- a/src/services/transport.ts
+++ b/src/services/transport.ts
@@ -19,6 +19,29 @@
 import { config } from "../config.js";
 import { isCloudflareChallengeHtml, isCloudflareBotBlock, cfBlockMessage } from "./cloudflare.js";
 import { isAustliiUrl } from "./austlii-url.js";
+import { assertFetchableUrl, assertRedirectAllowed, MAX_REDIRECTS } from "../utils/url-guard.js";
+
+/**
+ * impit follows redirects internally (bounded by {@link MAX_REDIRECTS}), so we
+ * cannot re-check each hop the way axios' `beforeRedirect` does. Instead, after
+ * the fetch, reject when the chain changed host to one that is not itself
+ * allowlisted — this blocks an allowlisted origin from bouncing us to an
+ * internal/metadata address (SSRF) while still permitting same-host redirects
+ * and AustLII's www<->classic hops. A same-host (or no) redirect is always fine.
+ */
+function assertNoUnsafeImpitRedirect(initialUrl: string, finalUrl: string | undefined): void {
+  if (!finalUrl) return;
+  let init: URL;
+  let fin: URL;
+  try {
+    init = new URL(initialUrl);
+    fin = new URL(finalUrl);
+  } catch {
+    return;
+  }
+  if (fin.hostname === init.hostname) return;
+  assertFetchableUrl(finalUrl);
+}
 
 export interface TransportResponse {
   body: string;
@@ -71,12 +94,13 @@ async function fetchWithImpit(url: string, options: TransportOptions): Promise<T
   }
 
   const browser = (config.transport.imitBrowser as import("impit").Browser) ?? "chrome";
-  const client = new mod.Impit({ browser });
+  const client = new mod.Impit({ browser, maxRedirects: MAX_REDIRECTS });
 
   const method = (options.method ?? "GET").toUpperCase() as import("impit").HttpMethod;
   const headers = options.headers ?? {};
 
   const response = await client.fetch(url, { method, headers });
+  assertNoUnsafeImpitRedirect(url, response.url);
 
   const body = await response.text();
   const status = response.status;
@@ -107,6 +131,8 @@ async function fetchWithAxios(url: string, options: TransportOptions): Promise<T
     headers: options.headers ?? {},
     timeout,
     responseType: "text",
+    maxRedirects: MAX_REDIRECTS,
+    beforeRedirect: assertRedirectAllowed,
   });
 
   const body = typeof response.data === "string" ? response.data : JSON.stringify(response.data);
@@ -194,17 +220,21 @@ class ImpitFetcher implements HttpFetcher {
       );
     }
     const browser = (config.transport.imitBrowser as import("impit").Browser) ?? "chrome";
-    const client = new mod.Impit({ browser });
+    const client = new mod.Impit({ browser, maxRedirects: MAX_REDIRECTS });
     const response = await client.fetch(url, {
       method: "GET",
       headers: opts.headers,
     });
+    // impit follows redirects internally; reject before consuming the body if
+    // the chain bounced cross-host to a disallowed address (SSRF hardening).
+    const finalUrl = response.url || url;
+    assertNoUnsafeImpitRedirect(url, response.url);
     const headers: Record<string, string> = {};
     response.headers.forEach((value: string, key: string) => {
       headers[key] = value;
     });
     const body = Buffer.from(await response.bytes());
-    return { status: response.status, headers, body, finalUrl: url, via: "impit" };
+    return { status: response.status, headers, body, finalUrl, via: "impit" };
   }
 }
 
@@ -215,6 +245,8 @@ class AxiosFetcher implements HttpFetcher {
       responseType: "arraybuffer",
       headers: opts.headers,
       timeout: opts.timeoutMs,
+      maxRedirects: MAX_REDIRECTS,
+      beforeRedirect: assertRedirectAllowed,
     });
     const headers: Record<string, string> = {};
     for (const [k, v] of Object.entries(response.headers)) {

--- a/src/test/unit/constants.test.ts
+++ b/src/test/unit/constants.test.ts
@@ -61,7 +61,9 @@ describe("Constants", () => {
     it("should have sensible values", () => {
       expect(DEFAULT_TIMEOUT_MS).toBe(30_000);
       expect(LONG_TIMEOUT_MS).toBe(60_000);
-      expect(MAX_CONTENT_LENGTH).toBe(50 * 1024 * 1024);
+      // Bounded to 10 MB so a single hostile/oversized response can't drive
+      // unbounded cheerio DOM + parse cost (DoS hardening).
+      expect(MAX_CONTENT_LENGTH).toBe(10 * 1024 * 1024);
     });
   });
 });

--- a/src/test/unit/fetch-module-security.test.ts
+++ b/src/test/unit/fetch-module-security.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  fetchModule,
+  verifyModule,
+  assertModuleUrl,
+  type FetchIO,
+} from "../../services/fetch-module.js";
+import { isSafeModuleFilePath, validateManifest } from "../../data/manifest.js";
+
+const sha = (buf: Buffer): string => crypto.createHash("sha256").update(buf).digest("hex");
+
+function baseManifest(over: Record<string, unknown> = {}): Record<string, unknown> {
+  const docBytes = Buffer.from("fake-parquet");
+  return {
+    name: "legislation-cth",
+    module_version: "1.0.0",
+    schema_version: 1,
+    yanked: false,
+    base_uri: "https://assets.test/m/",
+    snapshot: {
+      corpus_sha: "0".repeat(40),
+      date: "2026-01-01",
+      recipe_repo: "r/d",
+      recipe_git_sha: "abcdef0",
+      args: {},
+    },
+    coverage: {
+      jurisdictions: ["commonwealth"],
+      types: ["primary_legislation"],
+      doc_count: 1,
+      chunk_count: 1,
+    },
+    embedding: null,
+    files: [{ path: "documents.parquet", sha256: sha(docBytes), rows: 1 }],
+    licence: { spdx: "CC-BY-4.0", per_source: [], attribution: [] },
+    ...over,
+  };
+}
+
+function mockIO(
+  manifest: unknown,
+  assets: Record<string, Buffer>,
+): FetchIO & { fetched: string[] } {
+  const fetched: string[] = [];
+  return {
+    fetched,
+    async fetchJson(url: string): Promise<unknown> {
+      fetched.push(url);
+      return manifest;
+    },
+    async fetchBytes(url: string): Promise<Buffer> {
+      fetched.push(url);
+      const key = url.split("/").pop()!;
+      const buf = assets[key];
+      if (!buf) throw new Error(`404 ${url}`);
+      return buf;
+    },
+  };
+}
+
+let modulesDir: string;
+beforeEach(() => {
+  modulesDir = fs.mkdtempSync(path.join(os.tmpdir(), "jurisd-sec-"));
+});
+afterEach(() => {
+  fs.rmSync(modulesDir, { recursive: true, force: true });
+});
+
+describe("isSafeModuleFilePath", () => {
+  it("accepts safe relative paths", () => {
+    for (const p of ["documents.parquet", "a/b/c.parquet", "x_y-z.bin", "Sub/File.txt"]) {
+      expect(isSafeModuleFilePath(p)).toBe(true);
+    }
+  });
+
+  it("rejects traversal, absolute, and exotic paths", () => {
+    for (const p of [
+      "../escape",
+      "../../etc/passwd",
+      "/etc/passwd",
+      "a/../../b",
+      "./hidden",
+      ".hidden",
+      "foo\\bar",
+      "with\0nul",
+      "",
+      "/",
+      123 as unknown,
+    ]) {
+      expect(isSafeModuleFilePath(p as unknown)).toBe(false);
+    }
+  });
+});
+
+describe("validateManifest security constraints", () => {
+  it("rejects a path-traversal files[].path (zip-slip)", () => {
+    const r = validateManifest(
+      baseManifest({ files: [{ path: "../../evil.sh", sha256: "a".repeat(64), rows: 1 }] }),
+    );
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("safe relative path");
+  });
+
+  it("rejects an absolute files[].path", () => {
+    const r = validateManifest(
+      baseManifest({ files: [{ path: "/home/op/.bashrc", sha256: "a".repeat(64), rows: 1 }] }),
+    );
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("safe relative path");
+  });
+
+  it("rejects a __proto__ key (prototype pollution)", () => {
+    // JSON.parse materialises __proto__ as an own enumerable property.
+    const hostile = JSON.parse('{"__proto__":{"polluted":true},"name":"x"}');
+    const r = validateManifest({ ...baseManifest(), ...hostile });
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("forbidden key");
+  });
+
+  it("rejects a non-https base_uri", () => {
+    const r = validateManifest(baseManifest({ base_uri: "http://assets.test/m/" }));
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("https");
+  });
+
+  it("rejects a file: / javascript: base_uri", () => {
+    for (const base_uri of ["file:///etc/", "javascript:alert(1)"]) {
+      const r = validateManifest(baseManifest({ base_uri }));
+      expect(r.valid).toBe(false);
+    }
+  });
+
+  it("accepts a well-formed manifest", () => {
+    expect(validateManifest(baseManifest()).valid).toBe(true);
+  });
+});
+
+describe("fetchModule path-traversal defence (end to end)", () => {
+  it("refuses to install a module whose manifest contains a traversal path, writing nothing outside the temp dir", async () => {
+    const evil = baseManifest({
+      files: [{ path: "../../../../tmp/jurisd-escape-poc", sha256: "a".repeat(64), rows: 1 }],
+    });
+    const io = mockIO(evil, {});
+    const r = await fetchModule("legislation-cth", {
+      manifestUrl: "https://gh.test/m/manifest.json",
+      modulesDir,
+      io,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/safe relative path|schema validation/);
+    expect(fs.existsSync("/tmp/jurisd-escape-poc")).toBe(false);
+    // Rejected at validation: no parquet fetch attempted.
+    expect(io.fetched.some((u) => u.includes("escape"))).toBe(false);
+  });
+});
+
+describe("verifyModule path-traversal defence", () => {
+  it("rejects an on-disk manifest with a traversal path instead of reading outside the module dir", () => {
+    const dir = path.join(modulesDir, "legislation-cth");
+    fs.mkdirSync(dir, { recursive: true });
+    const manifest = baseManifest({
+      files: [{ path: "../../../../etc/hostname", sha256: "a".repeat(64), rows: 1 }],
+    });
+    fs.writeFileSync(path.join(dir, "manifest.json"), JSON.stringify(manifest));
+    const r = verifyModule("legislation-cth", { modulesDir });
+    expect(r.ok).toBe(false);
+    // Either schema validation or the verify-site guard rejects it.
+    expect(r.error).toMatch(/safe relative path|schema validation/);
+  });
+});
+
+describe("assertModuleUrl (SSRF guard)", () => {
+  it("accepts Hugging Face hosts", () => {
+    for (const u of [
+      "https://huggingface.co/datasets/workingmem/legislation-cth/resolve/main/manifest.json",
+      "https://cdn-lfs.huggingface.co/datasets/x/file.parquet",
+      "https://cas-bridge.xethub.hf.co/x/file",
+    ]) {
+      expect(() => assertModuleUrl(u)).not.toThrow();
+    }
+  });
+
+  it("rejects internal/metadata addresses and non-https", () => {
+    for (const u of [
+      "http://huggingface.co/x", // not https
+      "https://169.254.169.254/latest/meta-data/", // metadata
+      "https://localhost/x",
+      "https://127.0.0.1/x",
+      "https://evil.example.com/x",
+      "https://huggingface.co.evil.com/x", // suffix-confusion
+      "file:///etc/passwd",
+    ]) {
+      expect(() => assertModuleUrl(u)).toThrow();
+    }
+  });
+});

--- a/src/test/unit/url-guard.test.ts
+++ b/src/test/unit/url-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { assertFetchableUrl } from "../../utils/url-guard.js";
+import { assertFetchableUrl, assertRedirectAllowed, MAX_REDIRECTS } from "../../utils/url-guard.js";
 
 describe("assertFetchableUrl", () => {
   it("permits AustLII HTTPS URL", () => {
@@ -28,5 +28,37 @@ describe("assertFetchableUrl", () => {
   });
   it("throws on invalid URL", () => {
     expect(() => assertFetchableUrl("not-a-url")).toThrow(/Invalid URL/);
+  });
+});
+
+describe("assertRedirectAllowed", () => {
+  it("permits a redirect to an allowlisted host (via href)", () => {
+    expect(() =>
+      assertRedirectAllowed({ href: "https://classic.austlii.edu.au/au/cases/x.html" }),
+    ).not.toThrow();
+  });
+  it("permits a redirect reconstructed from protocol/host/path", () => {
+    expect(() =>
+      assertRedirectAllowed({ protocol: "https:", host: "jade.io", path: "/article/1" }),
+    ).not.toThrow();
+  });
+  it("blocks a redirect to a cloud-metadata address", () => {
+    expect(() =>
+      assertRedirectAllowed({ href: "https://169.254.169.254/latest/meta-data/" }),
+    ).toThrow(/not in permitted/);
+  });
+  it("blocks a redirect to localhost", () => {
+    expect(() =>
+      assertRedirectAllowed({ protocol: "https:", host: "localhost", path: "/" }),
+    ).toThrow(/not in permitted/);
+  });
+  it("blocks a redirect downgraded to http", () => {
+    expect(() => assertRedirectAllowed({ href: "http://www.austlii.edu.au/x" })).toThrow(
+      /Only HTTPS/,
+    );
+  });
+  it("bounds the redirect chain to a small number", () => {
+    expect(MAX_REDIRECTS).toBeLessThanOrEqual(5);
+    expect(MAX_REDIRECTS).toBeGreaterThan(0);
   });
 });

--- a/src/utils/url-guard.ts
+++ b/src/utils/url-guard.ts
@@ -31,3 +31,35 @@ export function assertFetchableUrl(url: string): void {
     );
   }
 }
+
+/**
+ * Maximum redirects to follow on guarded fetches. `assertFetchableUrl` only
+ * validates the first hop; without a bound + per-hop re-check, a 302 from an
+ * allowlisted origin to an internal address (or a metadata endpoint) would be
+ * followed silently. Keep this small — legitimate AustLII/jade flows redirect
+ * at most once or twice.
+ */
+export const MAX_REDIRECTS = 3;
+
+/** The subset of axios' `beforeRedirect` options we read to rebuild the next-hop URL. */
+interface RedirectOptions {
+  protocol?: string;
+  host?: string;
+  hostname?: string;
+  path?: string;
+  href?: string;
+}
+
+/**
+ * axios `beforeRedirect` hook: re-validate every redirect hop against the
+ * allowlist so a redirect cannot escape to an internal/disallowed host
+ * (SSRF / DNS-rebind hardening).
+ *
+ * @throws {Error} If the redirect target is not a permitted URL.
+ */
+export function assertRedirectAllowed(options: RedirectOptions): void {
+  const href =
+    options.href ??
+    `${options.protocol ?? "https:"}//${options.host ?? options.hostname ?? ""}${options.path ?? ""}`;
+  assertFetchableUrl(href);
+}


### PR DESCRIPTION
## Security hardening — full-codebase review of `20c0e88`

Remediates the findings from a security review of jurisd (application code + CI/CD + container/k8s). Each finding was verified against source before fixing; every code fix ships with tests. No `jurisd-data` repo exists yet (dataset is on Hugging Face), so its attack surface is covered here via the module loader.

**Verification:** `npm test` 694 passed / 0 failed (6 live-network files skipped under `CI=true`, as in CI); `tsc --noEmit` clean; `eslint` 0 errors; `prettier --check` clean; `npm run build` OK; all workflow/k8s YAML and shell scripts syntax-validated; `npm ci` consistency confirmed against the edited lockfile.

### Application code

| ID | Sev | Fix |
|----|-----|-----|
| **C1** | Critical | **Module manifest path traversal (zip-slip).** `fetch-module.ts` wrote `path.join(tmpDir, file.path)` with no check — a hostile HF manifest could write outside the temp dir (sha256 was no defence: attacker controls both path and hash). Now rejected in `validateManifest` *and* re-checked at the write/verify sinks with the prefix-check pattern already used in `source-store.ts`. |
| **H1** | High | **SSRF on module fetch.** `manifestUrl`/`base_uri` reached a bare `fetch()`. Now constrained to HTTPS Hugging Face hosts via a manual-redirect secure fetch that re-validates every hop. |
| **H2** | High | **SSRF via unrevalidated redirects.** axios/jade calls followed redirects with no per-hop check. Added `beforeRedirect` + bounded `maxRedirects` (axios/jade) and cross-host rejection for impit. |
| **M1** | Med | **Unenforced schema (ajv absent).** `structuralValidate` now rejects `__proto__`/`constructor`/`prototype` and non-HTTPS `base_uri`, and enforces the safe-path constraint — security no longer depends on ajv being installed. Schema also gains a `files[].path` pattern. |
| **M2** | Med | **Parse DoS.** `MAX_CONTENT_LENGTH` 50 MB → 10 MB. |
| Low | Low | **bibliography `outputPath`.** Now confined to the cache dir (resolves within it, must end `.bib`). |

New tests: `fetch-module-security.test.ts` (traversal, proto-pollution, base_uri scheme, SSRF host guard), redirect cases in `url-guard.test.ts`.

### CI / supply chain

- **H3** — every GitHub Action SHA-pinned (with semver comment) across all three workflows; Dependabot maintains the pins.
- **H4** — top-level `permissions: contents: read` added to `docker.yml` (build job keeps only `packages: write`).
- **M5** — npm `prepare` gated to the dev clone (husky only when `.git` exists); no build-on-install code for consumers.
- Release notes env-bound instead of `${{ }}`-into-shell (injection hardening); `impit` pinned to exact `0.14.1`.

### Container / k8s

- **H5** — `imagePullPolicy: Always` for the floating tag (no stale/poisoned cached `:latest`); digest-pinning documented; **base image pinned by multi-arch manifest digest**.
- **M3** — default-deny `NetworkPolicy`: egress limited to DNS + HTTPS with RFC1918/CGNAT/link-local(169.254)/metadata excluded (network-layer SSRF backstop); ingress to `:3000`.
- **M4** — `readOnlyRootFilesystem: true` + `seccompProfile: RuntimeDefault` (pod + container) with `emptyDir` mounts for `/tmp` and `/data` and `AUSLAW_CACHE_DIR=/data/cache`.
- `set -euo pipefail` in `build.sh`/`deploy-k8s.sh`; Dependabot gains the docker ecosystem.

### Notes for the reviewer

- The `OWNER` placeholder in `k8s/deployment.yaml` is intentionally left for you to fill with the real GHCR owner / digest at deploy time.
- M1 is remediated in the dependency-free validator rather than by making `ajv` a hard dependency: that avoids coupling security to an optional package and avoids breaking the error-message contract several reject-tests assert on. The vendored schema still documents every constraint.
- impit redirect handling is post-hoc cross-host rejection (impit follows redirects internally); the axios paths get full per-hop `beforeRedirect` validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
