### PR TITLE
Prepare jurisd v0.2.0 release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ AUSTLII_TIMEOUT=60000
 
 # jade.io Configuration
 JADE_BASE_URL=https://jade.io
-JADE_USER_AGENT=jurisd/0.1.0 (legal research tool)
+JADE_USER_AGENT=jurisd/0.2.0 (legal research tool)
 JADE_TIMEOUT=15000
 # Required for jade.io authenticated features (search, full-text fetch).
 # Copy your session cookie from browser DevTools → Application → Cookies → jade.io.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,11 +3,28 @@ name: Build and Push Docker Image
 on:
   push:
     branches: [main]
+    tags:
+      - "v*"
     paths:
       - "src/**"
       - "package*.json"
       - "tsconfig.json"
+      - "tsconfig.build.json"
       - "Dockerfile"
+      - "docker-compose.yaml"
+      - "scripts/docker-handshake.mjs"
+      - ".github/workflows/docker.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "package*.json"
+      - "tsconfig.json"
+      - "tsconfig.build.json"
+      - "Dockerfile"
+      - "docker-compose.yaml"
+      - "scripts/docker-handshake.mjs"
+      - ".github/workflows/docker.yml"
   workflow_dispatch:
 
 env:
@@ -34,6 +51,7 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -47,13 +65,16 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha,prefix=
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           cache: "npm"
 
       - name: Install dependencies
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           cache: "npm"
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+No changes yet.
+
+## [0.2.0] - 2026-06-16
+
 ### Added
 
 - **Local-module data layer**: a Layer-1 offline recall path over installed
@@ -37,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `JURISD_MODULES_ENABLED`, `JURISD_MODULE_STALENESS_DAYS`, `JURISD_MODULE_VERIFY_ON_LOAD`,
   `JURISD_MODELS_DIR`, `JURISD_EMBED_OFFLINE`, and `ISAACUS_API_KEY` / `ISAACUS_BASE_URL`.
 - **Container image + release plumbing**: a multi-stage `Dockerfile` (Debian-slim
-  glibc Node 20; builds TS in a discarded builder, then a slim runtime carrying only
+  glibc Node 26; builds TS in a discarded builder, then a slim runtime carrying only
   the two optional natives the server uses — `@duckdb/node-api` and `impit` — while
   `@huggingface/transformers` stays unbundled to keep the image small), a
   `docker-compose.yaml` smoke-test/build example honest about the stdio per-invocation
@@ -96,7 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   local-first three-layer story (local data modules → live AustLII → OALC fallback), a
   grouped 15-tool table, the data-module / `fetch-module` / baseline-vs-domain-specialised /
   BYOK-adapter sections, an honest quality section linking the `jurisd-data` gold-set eval
-  (strict + aligned metrics), and per-source licensing notes (code MIT; module data per-source,
+  (strict + aligned metrics), and per-source licensing notes (code Apache-2.0; module data per-source,
   AustLII excluded, VIC/NT recipe-only). Added `docs/INSTALL.md` with day-0 install paths
   (npx-from-GitHub, local clone, Claude Code config), the all-optional env-var reference, the
   `fetch-module` install flow, and the offline/baseline guarantee.
@@ -147,5 +151,6 @@ legal research across AustLII and jade.io.
 - Source-store citeKey hardening against path traversal (#108)
 - Dependency updates resolving known HIGH severity advisories; npm audit in CI
 
-[Unreleased]: https://github.com/russellbrenner/jurisd/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/russellbrenner/jurisd/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/russellbrenner/jurisd/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/russellbrenner/jurisd/releases/tag/v0.1.0

--- a/LICENSE-THIRD-PARTY.md
+++ b/LICENSE-THIRD-PARTY.md
@@ -1,7 +1,7 @@
 # Third-Party Licenses
 
 This project depends on open-source packages. All production and development
-dependencies use permissive licenses compatible with this project's MIT license.
+dependencies use permissive licenses compatible with this project's Apache-2.0 license.
 
 ## License Summary
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ state, not a marketing number.
 
 ## Licensing
 
-- **Code:** MIT (see [LICENSE](LICENSE)). Third-party dependency licences are
+- **Code:** Apache-2.0 (see [LICENSE](LICENSE)). Third-party dependency licences are
   catalogued in [LICENSE-THIRD-PARTY.md](LICENSE-THIRD-PARTY.md).
 - **Module data:** licensed **per source**, declared in each module's
   `manifest.json` `licence` block, and surfaced at `fetch-module` install time.
@@ -346,4 +346,4 @@ advice.**
 
 ## License
 
-MIT
+Apache-2.0

--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@
 
 server:
   name: jurisd
-  version: 0.1.0
+  version: 0.2.0
   description: Australian legislation and case law searcher with document retrieval.
 
 austlii:
@@ -25,7 +25,7 @@ jade:
   baseUrl: ${JADE_BASE_URL:-https://jade.io}
 
   # User agent for jade.io requests
-  userAgent: ${JADE_USER_AGENT:-jurisd/0.1.0 (legal research tool)}
+  userAgent: ${JADE_USER_AGENT:-jurisd/0.2.0 (legal research tool)}
 
   # Request timeout in milliseconds
   timeout: ${JADE_TIMEOUT:-15000}

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -524,5 +524,5 @@
 
 ---
 
-**License:** MIT  
+**License:** Apache-2.0
 **Contact:** contact@workingmem.ai

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,4 +185,4 @@ npx vitest run src/test/unit/   # Unit only (fast, no network)
 
 ---
 
-**License:** MIT
+**License:** Apache-2.0

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,6 +1,6 @@
 # Running jurisd in Docker
 
-jurisd ships as a multi-stage container image: a Debian-slim Node 20 runtime
+jurisd ships as a multi-stage container image: a Debian-slim Node 26 runtime
 with the compiled server and the two native dependencies that make the
 local-data and Cloudflare-aware fetch paths work (`@duckdb/node-api`, `impit`).
 
@@ -43,7 +43,7 @@ publish prebuilt binaries for `linux-x64-gnu` and `linux-arm64-gnu`. On Apple
 Silicon (podman/Docker Desktop default arm64 VM) you get the arm64 prebuild; on
 an x86 host, the x64 prebuild. Cross-building for a different arch requires
 `--platform` and an emulator (qemu/binfmt); the prebuilds still resolve because
-they are glibc-targeted (this is why the base is `node:20-bookworm-slim`, not
+they are glibc-targeted (this is why the base is `node:26-bookworm-slim`, not
 Alpine/musl).
 
 ## Use with Claude Code

--- a/docs/superpowers/plans/2026-06-16-cli-tui-foundation-pr1.md
+++ b/docs/superpowers/plans/2026-06-16-cli-tui-foundation-pr1.md
@@ -1,0 +1,1412 @@
+# CLI/TUI Foundation PR 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build Foundation PR 1 for jurisd: repo conventions, command contract architecture, MCP compatibility protection, CLI grouped-help skeleton, docs skeleton, and security checklist without implementing corpus, graph, vector, provider, completions, or full TUI features.
+
+**Architecture:** Introduce a typed command contract layer that becomes the single metadata source for CLI, docs, future TUI, future completions, and MCP compatibility checks. Keep existing MCP tool behaviour stable by registering the current 15 tools exactly as before, while adding generated compatibility reference tests and CLI routing through command contract metadata. This PR is intentionally a foundation slice, not the full legal reasoning workbench.
+
+**Tech Stack:** TypeScript, Node.js ESM, zod, MCP SDK, Vitest, existing no-framework CLI dispatch, markdown docs.
+
+---
+
+## Team-leader operating model
+
+This plan is intended for an agent swarm with one team leader and short-lived worker agents.
+
+Team leader responsibilities:
+
+1. Keep the branch clean and protect Russ's unrelated working-tree changes.
+2. Assign one task at a time to workers, or run independent doc and test tasks in parallel.
+3. Review each worker diff before allowing the next dependent task.
+4. Run the task-specific tests before marking a task complete.
+5. Run final verification before PR creation.
+6. Do not commit secrets or environment files.
+7. Do not add AI-generated or co-authored commit trailers.
+
+Known pre-existing uncommitted files at planning time:
+
+```text
+M build.sh
+?? docs/DOGFOODING.md
+?? podman-build.sh
+```
+
+Workers must not modify or stage those files unless the team leader explicitly changes scope.
+
+Recommended swarm allocation:
+
+```text
+Task 1  docs/conventions worker
+Task 2  MCP compatibility worker
+Task 3  command contract worker
+Task 4  CLI routing/help worker
+Task 5  docs skeleton worker
+Task 6  security checklist worker
+Task 7  integration/verification worker
+Task 8  team leader final review and PR
+```
+
+---
+
+## File structure
+
+Create:
+
+- `AGENTS.md`
+  - Agent-facing repo rules, architecture map, generated-file policy, security constraints, how to add a command once.
+- `docs/CLI.md`
+  - Authored CLI guide skeleton and grouped command overview.
+- `docs/SECURITY-AUTHORITY.md`
+  - Authority, side-effect classes, terminal safety, credentials, MCP exposure, and first PR security checklist.
+- `docs/MCP-COMPATIBILITY.md`
+  - Generated or committed reference listing the current MCP compatibility set.
+- `src/commands/types.ts`
+  - Command contract and authority metadata types.
+- `src/commands/contracts.ts`
+  - Command contracts for the existing 15 MCP-backed CLI tools plus CLI-only module-management commands.
+- `src/commands/help.ts`
+  - Pure help rendering from command contracts.
+- `src/commands/legacy-cli.ts`
+  - Compatibility helpers that map existing flat commands to command contracts.
+- `src/test/unit/command-contracts.test.ts`
+  - Registry completeness and metadata tests.
+- `src/test/unit/mcp-compatibility.test.ts`
+  - Current 15 MCP tool compatibility reference test.
+- `src/test/unit/cli-help.test.ts`
+  - Help rendering and grouped command UX tests.
+
+Modify:
+
+- `src/cli.ts`
+  - Replace hard-coded `TOOL_COMMANDS` with contract-derived routing while preserving `runCli()` behaviour and module-management commands.
+- `src/test/unit/cli.test.ts`
+  - Update mapping tests to use exported contract-derived command metadata, not inlined duplicate shapes.
+- `src/test/unit/tool-surface.test.ts`
+  - Keep existing exact 15-tool surface test, optionally import expected names from the compatibility reference.
+- `CONTRIBUTING.md`
+  - Add command contract, docs, security, and test requirements.
+- `README.md`
+  - Add a short CLI/TUI foundation note and link to `docs/CLI.md`, without claiming unbuilt corpus/graph/vector functionality.
+
+Do not modify in this PR:
+
+- `src/server.ts`, except if a compile-only import needs changing. The current MCP server behaviour must stay stable.
+- `src/services/*`, except if tests reveal a type-only export is needed.
+- `package.json`, unless a test script addition is approved by the team leader.
+
+---
+
+## Task 1: Add repo conventions and contributor guardrails
+
+**Files:**
+
+- Create: `AGENTS.md`
+- Modify: `CONTRIBUTING.md`
+
+- [ ] **Step 1: Write failing convention-doc presence test by grep command**
+
+Run before creating files:
+
+```bash
+test -f AGENTS.md && grep -q "command contract registry" AGENTS.md
+```
+
+Expected: FAIL because `AGENTS.md` does not exist.
+
+- [ ] **Step 2: Create `AGENTS.md`**
+
+Write this exact content, then adjust only if the repo already has conflicting instructions discovered during implementation:
+
+```markdown
+# Agent instructions for jurisd
+
+## Purpose
+
+jurisd is a source-backed Australian legal research and provenance instrument over a governed command surface. It exposes legal research capabilities through MCP, CLI, and future TUI adapters.
+
+Do not describe jurisd as a chatbot, oracle, AI companion, or autonomous legal advice system.
+
+## Current foundation architecture
+
+- `src/server.ts` registers the current MCP tool surface.
+- `src/cli.ts` handles CLI entry before the server starts.
+- `src/commands/types.ts` defines command contract and authority metadata types.
+- `src/commands/contracts.ts` is the command contract registry for CLI/docs/future adapters.
+- `docs/MCP-COMPATIBILITY.md` records the current MCP compatibility set.
+
+## Command contract rule
+
+Add commands once through the command contract registry.
+
+Every public command needs:
+
+- stable command id
+- synopsis
+- summary
+- arguments
+- flags
+- stdin mode
+- output modes
+- exit codes
+- validation schema reference or adapter mapping
+- stability level
+- side-effect class
+- terminal safety policy
+- capability gates
+- result contract
+
+Adapter-specific metadata is required when that adapter is enabled.
+
+## MCP surface rule
+
+MCP exposure is curated. Do not expose operator, install, update, destructive, filesystem-write, or network-write commands over MCP unless a later authority decision explicitly permits it.
+
+Existing MCP tool names are compatibility-sensitive. Update the compatibility reference and tests before changing the tool surface.
+
+## Security invariants
+
+- No secrets in code, docs, logs, tests, command output, or examples.
+- No shell execution with user-controlled strings.
+- Treat CLI args, TUI input, MCP input, provider output, source text, filenames, URLs, and completion candidates as untrusted.
+- Keep stdout for primary output and stderr for diagnostics.
+- JSON and NDJSON output must not contain terminal decoration.
+- Terminal output must strip or neutralise unsafe ANSI, OSC, control characters, and bidi controls when it renders untrusted text.
+
+## Generated files
+
+Generated command references and compatibility references must be deterministic. If a generated section changes, commit the generator input and output together.
+
+## Required checks before marking code complete
+
+Run the smallest relevant checks first, then the full suite before handoff:
+
+```bash
+npm run build
+npm test
+npm run lint
+npm run format:check
+```
+
+If a check fails twice, stop and reassess rather than iterating blindly.
+
+## Anti-slop documentation rules
+
+- Use concrete commands and examples.
+- Do not write vague product promises.
+- Do not claim graph, vector, corpus, Isaacus, Evidence Pack, or agentic TUI functionality exists before it is built.
+- Separate authored guides from generated references.
+```
+
+- [ ] **Step 3: Extend `CONTRIBUTING.md`**
+
+Add this section after the existing `## Development Guidelines` heading or immediately before it if the heading content is not easy to extend:
+
+```markdown
+### Command contracts and public surfaces
+
+jurisd has multiple public adapters: MCP, CLI, and future TUI. Do not add or change a public command by editing one adapter only.
+
+For any command-surface change:
+
+1. Update the command contract registry.
+2. Update or regenerate public help/reference docs.
+3. Update MCP compatibility reference if MCP exposure changes.
+4. Add or update tests for CLI routing, help, metadata completeness, and MCP compatibility.
+5. Document side-effect class, capability gates, and output behaviour.
+
+MCP tools are curated. Operator/install/update/destructive commands remain CLI-only unless a later authority decision explicitly allows MCP exposure.
+
+### Security-sensitive changes
+
+Run an explicit security review for changes involving:
+
+- URLs or source fetching
+- local file paths
+- credentials or provider keys
+- terminal rendering
+- shell completions
+- MCP tool exposure
+- command parsing
+- graph/corpus/review mutations
+
+Never commit secrets, `.env` files, provider tokens, cookies, or credential-bearing URLs.
+```
+
+- [ ] **Step 4: Verify docs exist and contain key rules**
+
+Run:
+
+```bash
+grep -q "command contract registry" AGENTS.md
+grep -q "MCP tools are curated" AGENTS.md
+grep -q "Command contracts and public surfaces" CONTRIBUTING.md
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add AGENTS.md CONTRIBUTING.md
+git commit -m "docs: add agent command-surface conventions"
+```
+
+---
+
+## Task 2: Add MCP compatibility reference and tests
+
+**Files:**
+
+- Create: `docs/MCP-COMPATIBILITY.md`
+- Create: `src/test/unit/mcp-compatibility.test.ts`
+- Modify: `src/test/unit/tool-surface.test.ts` only if sharing expected names reduces duplication without hiding intent.
+
+- [ ] **Step 1: Write failing MCP compatibility test**
+
+Create `src/test/unit/mcp-compatibility.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { createMcpServer } from "../../server.js";
+
+const MCP_COMPATIBILITY_TOOL_NAMES = [
+  "bibliography",
+  "cache_cited_by",
+  "cite",
+  "fetch_document_text",
+  "find_citing",
+  "format_citation",
+  "get_act_structure",
+  "get_provision",
+  "jade_lookup",
+  "list_data_modules",
+  "resolve_citation",
+  "search_cases",
+  "search_citing_cases",
+  "search_legislation",
+  "semantic_search_local",
+].sort();
+
+interface ToolBearingServer {
+  _registeredTools: Record<string, unknown>;
+}
+
+function registeredToolNames(): string[] {
+  const server = createMcpServer() as unknown as ToolBearingServer;
+  return Object.keys(server._registeredTools).sort();
+}
+
+describe("MCP compatibility reference", () => {
+  it("keeps the current 15 MCP tool names stable", () => {
+    expect(registeredToolNames()).toEqual(MCP_COMPATIBILITY_TOOL_NAMES);
+  });
+
+  it("documents the current compatibility count", () => {
+    expect(MCP_COMPATIBILITY_TOOL_NAMES).toHaveLength(15);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run:
+
+```bash
+npx vitest run src/test/unit/mcp-compatibility.test.ts
+```
+
+Expected: PASS. This is a characterisation test. If it fails, stop and inspect the current MCP surface before continuing.
+
+- [ ] **Step 3: Create `docs/MCP-COMPATIBILITY.md`**
+
+Write:
+
+```markdown
+# MCP compatibility reference
+
+This file records the current jurisd MCP tool surface for Foundation PR 1. The purpose is compatibility protection, not product documentation.
+
+## Compatibility rule
+
+MCP tool names are stable `snake_case` adapter aliases. Do not rename, remove, or add MCP tools without updating this reference, the MCP compatibility test, and release notes.
+
+MCP exposure is curated. Operator, install, update, destructive, filesystem-write, and network-write commands remain CLI-only unless a later authority decision explicitly allows them.
+
+## Current tool set
+
+| Tool | Status | Notes |
+|---|---|---|
+| `bibliography` | stable | Citation cache bibliography output |
+| `cache_cited_by` | stable | Cache cited-by information |
+| `cite` | stable | Citation helper |
+| `fetch_document_text` | stable | Fetch document text from allowed sources |
+| `find_citing` | stable | Local module graph recall |
+| `format_citation` | stable | AGLC4 citation formatting |
+| `get_act_structure` | stable | Local module act structure |
+| `get_provision` | stable | Local module provision lookup |
+| `jade_lookup` | stable | jade.io article or citation lookup |
+| `list_data_modules` | stable | Local module listing |
+| `resolve_citation` | stable | Citation resolution |
+| `search_cases` | stable | Case search |
+| `search_citing_cases` | stable | Citing case search |
+| `search_legislation` | stable | Legislation search |
+| `semantic_search_local` | stable | Local semantic search over installed modules |
+
+## Verification
+
+The compatibility test is `src/test/unit/mcp-compatibility.test.ts`.
+
+Run:
+
+```bash
+npx vitest run src/test/unit/mcp-compatibility.test.ts src/test/unit/tool-surface.test.ts
+```
+
+Expected: both tests pass and report exactly 15 registered MCP tools.
+```
+
+- [ ] **Step 4: Verify docs and tests**
+
+Run:
+
+```bash
+grep -q "search_cases" docs/MCP-COMPATIBILITY.md
+npx vitest run src/test/unit/mcp-compatibility.test.ts src/test/unit/tool-surface.test.ts
+```
+
+Expected: grep exits 0, tests pass.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add docs/MCP-COMPATIBILITY.md src/test/unit/mcp-compatibility.test.ts src/test/unit/tool-surface.test.ts
+git commit -m "test: pin MCP compatibility surface"
+```
+
+If `src/test/unit/tool-surface.test.ts` was not changed, omit it from `git add`.
+
+---
+
+## Task 3: Introduce command contract types and registry
+
+**Files:**
+
+- Create: `src/commands/types.ts`
+- Create: `src/commands/contracts.ts`
+- Create: `src/test/unit/command-contracts.test.ts`
+
+- [ ] **Step 1: Create failing contract test**
+
+Create `src/test/unit/command-contracts.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { COMMAND_CONTRACTS, getCommandContractByCliName } from "../../commands/contracts.js";
+
+const REQUIRED_MCP_TOOLS = [
+  "bibliography",
+  "cache_cited_by",
+  "cite",
+  "fetch_document_text",
+  "find_citing",
+  "format_citation",
+  "get_act_structure",
+  "get_provision",
+  "jade_lookup",
+  "list_data_modules",
+  "resolve_citation",
+  "search_cases",
+  "search_citing_cases",
+  "search_legislation",
+  "semantic_search_local",
+].sort();
+
+describe("command contracts", () => {
+  it("defines one contract for each current MCP-backed CLI command", () => {
+    const mcpTools = COMMAND_CONTRACTS
+      .filter((contract) => contract.adapters.mcp.enabled)
+      .map((contract) => contract.adapters.mcp.toolName)
+      .sort();
+
+    expect(mcpTools).toEqual(REQUIRED_MCP_TOOLS);
+  });
+
+  it("requires command metadata used by help and docs", () => {
+    for (const contract of COMMAND_CONTRACTS) {
+      expect(contract.id).toMatch(/^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)+$/);
+      expect(contract.summary.length).toBeGreaterThan(8);
+      expect(contract.synopsis.length).toBeGreaterThan(0);
+      expect(contract.sideEffectClass).toBeTruthy();
+      expect(contract.resultContract).toMatch(/\.v\d+$/);
+      expect(contract.outputModes).toContain("human");
+      expect(contract.outputModes).toContain("json");
+    }
+  });
+
+  it("maps existing flat CLI command names to contracts", () => {
+    expect(getCommandContractByCliName("search-cases")?.id).toBe("search.cases");
+    expect(getCommandContractByCliName("format-citation")?.id).toBe("cite.format");
+    expect(getCommandContractByCliName("semantic-search-local")?.id).toBe("search.semanticLocal");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run src/test/unit/command-contracts.test.ts
+```
+
+Expected: FAIL because `src/commands/contracts.ts` does not exist.
+
+- [ ] **Step 3: Create `src/commands/types.ts`**
+
+```ts
+export type OutputMode = "human" | "json" | "ndjson" | "plain" | "markdown";
+
+export type SideEffectClass =
+  | "read_only_query"
+  | "local_metadata_read"
+  | "network_read"
+  | "credential_dependent_read"
+  | "corpus_write"
+  | "graph_write"
+  | "review_state_write"
+  | "export_write"
+  | "filesystem_write"
+  | "network_write"
+  | "destructive_admin";
+
+export type Stability = "stable" | "experimental" | "future";
+
+export interface CommandArgumentContract {
+  name: string;
+  required: boolean;
+  summary: string;
+}
+
+export interface CommandFlagContract {
+  name: string;
+  type: "string" | "number" | "boolean" | "array";
+  summary: string;
+  values?: string[];
+}
+
+export interface CliAdapterContract {
+  enabled: boolean;
+  canonicalName?: string;
+  aliases: string[];
+  positional: string[];
+  numeric: string[];
+  boolean: string[];
+  array: string[];
+  group: string;
+}
+
+export interface McpAdapterContract {
+  enabled: boolean;
+  toolName?: string;
+}
+
+export interface TuiAdapterContract {
+  enabled: boolean;
+  label?: string;
+}
+
+export interface CommandContract {
+  id: string;
+  synopsis: string;
+  summary: string;
+  description: string;
+  stability: Stability;
+  sideEffectClass: SideEffectClass;
+  dangerous: boolean;
+  requiresConfirmation: boolean;
+  stdinMode: "none" | "json" | "ndjson" | "text";
+  outputModes: OutputMode[];
+  exitCodes: number[];
+  resultContract: string;
+  capabilityGates: string[];
+  arguments: CommandArgumentContract[];
+  flags: CommandFlagContract[];
+  examples: string[];
+  adapters: {
+    cli: CliAdapterContract;
+    mcp: McpAdapterContract;
+    tui: TuiAdapterContract;
+  };
+}
+```
+
+- [ ] **Step 4: Create `src/commands/contracts.ts` with current contracts**
+
+Use this structure. Include all 15 MCP-backed contracts and 3 CLI-only module operator contracts. Do not expose CLI-only operator contracts over MCP.
+
+```ts
+import type { CommandContract } from "./types.js";
+
+export const COMMAND_CONTRACTS: CommandContract[] = [
+  {
+    id: "search.legislation",
+    synopsis: "jurisd search legislation <query> [--jurisdiction cth] [--limit 10]",
+    summary: "Search Australian and New Zealand legislation.",
+    description: "Search legislation using the existing MCP search_legislation tool.",
+    stability: "stable",
+    sideEffectClass: "network_read",
+    dangerous: false,
+    requiresConfirmation: false,
+    stdinMode: "none",
+    outputModes: ["human", "json", "plain"],
+    exitCodes: [0, 1, 2, 3, 4, 6],
+    resultContract: "legal_search_results.v1",
+    capabilityGates: [],
+    arguments: [{ name: "query", required: true, summary: "Search query." }],
+    flags: [
+      { name: "jurisdiction", type: "string", summary: "Jurisdiction code." },
+      { name: "limit", type: "number", summary: "Maximum result count." },
+      { name: "offset", type: "number", summary: "Pagination offset." },
+      { name: "format", type: "string", summary: "Output format." },
+      { name: "sort-by", type: "string", summary: "Sort mode." },
+      { name: "method", type: "string", summary: "Search method." },
+    ],
+    examples: ["jurisd search legislation \"family violence\" --jurisdiction nsw"],
+    adapters: {
+      cli: {
+        enabled: true,
+        canonicalName: "search-legislation",
+        aliases: ["search-legislation"],
+        positional: ["query"],
+        numeric: ["limit", "offset"],
+        boolean: [],
+        array: [],
+        group: "search",
+      },
+      mcp: { enabled: true, toolName: "search_legislation" },
+      tui: { enabled: false, label: "Search legislation" },
+    },
+  },
+  {
+    id: "search.cases",
+    synopsis: "jurisd search cases <query> [--jurisdiction cth] [--limit 10]",
+    summary: "Search Australian and New Zealand case law.",
+    description: "Search cases using the existing MCP search_cases tool.",
+    stability: "stable",
+    sideEffectClass: "network_read",
+    dangerous: false,
+    requiresConfirmation: false,
+    stdinMode: "none",
+    outputModes: ["human", "json", "plain"],
+    exitCodes: [0, 1, 2, 3, 4, 6],
+    resultContract: "legal_search_results.v1",
+    capabilityGates: [],
+    arguments: [{ name: "query", required: true, summary: "Search query." }],
+    flags: [
+      { name: "jurisdiction", type: "string", summary: "Jurisdiction code." },
+      { name: "limit", type: "number", summary: "Maximum result count." },
+      { name: "offset", type: "number", summary: "Pagination offset." },
+      { name: "format", type: "string", summary: "Output format." },
+      { name: "sort-by", type: "string", summary: "Sort mode." },
+      { name: "method", type: "string", summary: "Search method." },
+    ],
+    examples: ["jurisd search cases \"native title\" --jurisdiction cth --limit 5"],
+    adapters: {
+      cli: {
+        enabled: true,
+        canonicalName: "search-cases",
+        aliases: ["search-cases"],
+        positional: ["query"],
+        numeric: ["limit", "offset"],
+        boolean: [],
+        array: [],
+        group: "search",
+      },
+      mcp: { enabled: true, toolName: "search_cases" },
+      tui: { enabled: false, label: "Search cases" },
+    },
+  },
+  makeContract("source.fetchDocument", "fetch-document-text", "fetch_document_text", "source", "network_read", ["url"], [], [], [], "Fetch full text for a source document.", "jurisd fetch-document-text <url>"),
+  makeContract("source.jadeLookup", "jade-lookup", "jade_lookup", "source", "network_read", [], ["articleId"], [], [], "Look up jade.io article metadata or citation URL.", "jurisd jade-lookup --by citation --citation '[2008] NSWSC 323'"),
+  makeContract("cite.format", "format-citation", "format_citation", "cite", "read_only_query", ["title"], ["footnoteRef", "pinpointPara", "pinpointPage", "paragraphNumber"], [], [], "Format an AGLC4 citation.", "jurisd format-citation 'Mabo v Queensland (No 2)' --neutral-citation '[1992] HCA 23'"),
+  makeContract("cite.resolve", "resolve-citation", "resolve_citation", "cite", "network_read", ["citation"], [], [], [], "Resolve a citation to an authoritative source.", "jurisd resolve-citation '[1992] HCA 23'"),
+  makeContract("cite.searchCitingCases", "search-citing-cases", "search_citing_cases", "cite", "network_read", ["caseName"], [], [], [], "Search for cases citing a named case.", "jurisd search-citing-cases 'Mabo v Queensland (No 2)'"),
+  makeContract("cite.cacheCitedBy", "cache-cited-by", "cache_cited_by", "cite", "network_read", ["citeKey"], [], [], [], "Cache cited-by information for a citation key.", "jurisd cache-cited-by mabo-1992-hca-23"),
+  makeContract("cite.create", "cite", "cite", "cite", "local_metadata_read", ["title"], ["year", "footnoteNumber"], [], ["keywords"], "Create or record a citation cache entry.", "jurisd cite 'Mabo v Queensland (No 2)' --year 1992"),
+  makeContract("cite.bibliography", "bibliography", "bibliography", "cite", "local_metadata_read", [], [], [], [], "Render a bibliography from cached citations.", "jurisd bibliography"),
+  makeContract("corpus.getProvision", "get-provision", "get_provision", "corpus", "local_metadata_read", ["act", "provision"], [], [], [], "Get a provision from an installed local data module.", "jurisd get-provision 'Family Law Act 1975 (Cth)' 's 60CC'"),
+  makeContract("corpus.getActStructure", "get-act-structure", "get_act_structure", "corpus", "local_metadata_read", ["act"], ["depth"], [], [], "Get act structure from an installed local data module.", "jurisd get-act-structure 'Family Law Act 1975 (Cth)'"),
+  makeContract("graph.findCiting", "find-citing", "find_citing", "graph", "local_metadata_read", ["target"], ["limit"], [], ["kinds"], "Find locally indexed items citing or considering a target.", "jurisd find-citing '[1992] HCA 23' --kinds cites,considers"),
+  makeContract("search.semanticLocal", "semantic-search-local", "semantic_search_local", "search", "local_metadata_read", ["query"], ["k"], [], [], "Run local semantic search over installed data modules.", "jurisd semantic-search-local 'restraint of trade' --k 5"),
+  makeContract("corpus.listDataModules", "list-data-modules", "list_data_modules", "corpus", "local_metadata_read", [], [], ["refresh", "includeInvalid"], [], "List installed local data modules.", "jurisd list-data-modules --include-invalid true"),
+];
+
+export function getCommandContractByCliName(name: string): CommandContract | undefined {
+  return COMMAND_CONTRACTS.find(
+    (contract) =>
+      contract.adapters.cli.enabled &&
+      (contract.adapters.cli.canonicalName === name || contract.adapters.cli.aliases.includes(name)),
+  );
+}
+
+export function getMcpBackedCommandContracts(): CommandContract[] {
+  return COMMAND_CONTRACTS.filter((contract) => contract.adapters.mcp.enabled);
+}
+```
+
+Add this helper above `COMMAND_CONTRACTS` in `src/commands/contracts.ts` so the `makeContract(...)` calls above compile:
+
+```ts
+function makeContract(
+  id: string,
+  cliName: string,
+  mcpToolName: string,
+  group: string,
+  sideEffectClass: CommandContract["sideEffectClass"],
+  positional: string[],
+  numeric: string[],
+  boolean: string[],
+  array: string[],
+  summary: string,
+  synopsis: string,
+): CommandContract {
+  return {
+    id,
+    synopsis,
+    summary,
+    description: summary,
+    stability: "stable",
+    sideEffectClass,
+    dangerous: false,
+    requiresConfirmation: false,
+    stdinMode: "none",
+    outputModes: ["human", "json", "plain"],
+    exitCodes: [0, 1, 2],
+    resultContract: `${id}.v1`,
+    capabilityGates: [],
+    arguments: positional.map((name) => ({ name, required: true, summary: `${name} argument.` })),
+    flags: [
+      ...numeric.map((name) => ({ name: name.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`), type: "number" as const, summary: `${name} value.` })),
+      ...boolean.map((name) => ({ name: name.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`), type: "boolean" as const, summary: `${name} toggle.` })),
+      ...array.map((name) => ({ name, type: "array" as const, summary: `${name} values.` })),
+    ],
+    examples: [synopsis],
+    adapters: {
+      cli: {
+        enabled: true,
+        canonicalName: cliName,
+        aliases: [cliName],
+        positional,
+        numeric,
+        boolean,
+        array,
+        group,
+      },
+      mcp: { enabled: true, toolName: mcpToolName },
+      tui: { enabled: false, label: summary.replace(/\.$/, "") },
+    },
+  };
+}
+```
+
+For CLI-only module commands, add three contracts with MCP disabled:
+
+```ts
+makeCliOnlyContract("modules.fetch", "fetch-module", "modules", "filesystem_write", ["name"], [], [], [], "Fetch and install a data module.", "jurisd fetch-module <name>"),
+makeCliOnlyContract("modules.verify", "verify-module", "modules", "local_metadata_read", ["name"], [], [], [], "Verify an installed data module.", "jurisd verify-module <name>"),
+makeCliOnlyContract("modules.list", "list-modules", "modules", "local_metadata_read", [], [], [], [], "List installed data modules via the operator CLI.", "jurisd list-modules"),
+```
+
+Define `makeCliOnlyContract(...)` by copying `makeContract(...)` and changing only:
+
+```ts
+mcp: { enabled: false }
+```
+
+These CLI-only contracts are metadata for help/docs/future adapters only. Keep the existing direct implementation of `fetch-module`, `verify-module`, and `list-modules` in `src/cli.ts` unchanged in Foundation PR 1.
+
+- [ ] **Step 5: Run contract tests**
+
+```bash
+npx vitest run src/test/unit/command-contracts.test.ts
+```
+
+Expected: PASS after all contracts are filled.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add src/commands/types.ts src/commands/contracts.ts src/test/unit/command-contracts.test.ts
+git commit -m "feat: add command contract registry"
+```
+
+---
+
+## Task 4: Route CLI tool commands through command contracts
+
+**Files:**
+
+- Create: `src/commands/legacy-cli.ts`
+- Modify: `src/cli.ts`
+- Modify: `src/test/unit/cli.test.ts`
+
+- [ ] **Step 1: Create failing test expectation for contract lookup**
+
+Modify `src/test/unit/cli.test.ts` imports:
+
+```ts
+import { getCommandContractByCliName } from "../../commands/contracts.js";
+```
+
+Add this test under `describe("runCli routing", ...)`:
+
+```ts
+it("resolves existing flat CLI tool commands from command contracts", () => {
+  expect(getCommandContractByCliName("search-cases")?.adapters.mcp.toolName).toBe("search_cases");
+  expect(getCommandContractByCliName("get-provision")?.adapters.mcp.toolName).toBe("get_provision");
+});
+```
+
+- [ ] **Step 2: Run the CLI tests**
+
+```bash
+npx vitest run src/test/unit/cli.test.ts
+```
+
+Expected: PASS if Task 3 is complete. If it fails, fix contract names before continuing.
+
+- [ ] **Step 3: Create `src/commands/legacy-cli.ts`**
+
+```ts
+import type { CommandContract } from "./types.js";
+
+export interface ToolCommand {
+  tool: string;
+  positional: string[];
+  numeric: string[];
+  boolean: string[];
+  array: string[];
+}
+
+export function contractToToolCommand(contract: CommandContract): ToolCommand {
+  if (!contract.adapters.mcp.enabled || !contract.adapters.mcp.toolName) {
+    throw new Error(`Command ${contract.id} is not backed by an MCP tool`);
+  }
+
+  return {
+    tool: contract.adapters.mcp.toolName,
+    positional: contract.adapters.cli.positional,
+    numeric: contract.adapters.cli.numeric,
+    boolean: contract.adapters.cli.boolean,
+    array: contract.adapters.cli.array,
+  };
+}
+```
+
+- [ ] **Step 4: Modify `src/cli.ts` imports**
+
+Add:
+
+```ts
+import { getCommandContractByCliName } from "./commands/contracts.js";
+import { contractToToolCommand } from "./commands/legacy-cli.js";
+```
+
+Remove or stop using the old `TOOL_COMMANDS` object. Keep the `ToolCommand` interface only if still needed by `mapArgvToToolInput`, or import it from `legacy-cli.ts`.
+
+- [ ] **Step 5: Modify `runCli()` contract lookup**
+
+Replace:
+
+```ts
+const toolCommand = TOOL_COMMANDS[command];
+if (toolCommand) {
+```
+
+with:
+
+```ts
+const contract = getCommandContractByCliName(command);
+const toolCommand = contract?.adapters.mcp.enabled ? contractToToolCommand(contract) : undefined;
+if (toolCommand) {
+```
+
+Keep the rest of the block unchanged.
+
+- [ ] **Step 6: Run CLI tests**
+
+```bash
+npx vitest run src/test/unit/cli.test.ts src/test/unit/command-contracts.test.ts
+```
+
+Expected: PASS. Existing loopback tests must still pass.
+
+- [ ] **Step 7: Commit Task 4**
+
+```bash
+git add src/cli.ts src/commands/legacy-cli.ts src/test/unit/cli.test.ts
+git commit -m "refactor: derive CLI tool routing from command contracts"
+```
+
+---
+
+## Task 5: Add contract-driven help rendering skeleton
+
+**Files:**
+
+- Create: `src/commands/help.ts`
+- Create: `src/test/unit/cli-help.test.ts`
+- Modify: `src/cli.ts`
+
+- [ ] **Step 1: Write failing help renderer tests**
+
+Create `src/test/unit/cli-help.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { renderCommandHelp, renderTopLevelHelp } from "../../commands/help.js";
+import { getCommandContractByCliName } from "../../commands/contracts.js";
+
+describe("CLI help rendering", () => {
+  it("renders task-oriented top-level help", () => {
+    const help = renderTopLevelHelp();
+    expect(help).toContain("jurisd");
+    expect(help).toContain("search");
+    expect(help).toContain("cite");
+    expect(help).toContain("mcp");
+    expect(help).toContain("Run `jurisd help <topic>`");
+  });
+
+  it("renders per-command help from a command contract", () => {
+    const contract = getCommandContractByCliName("search-cases");
+    expect(contract).toBeDefined();
+    const help = renderCommandHelp(contract!);
+    expect(help).toContain("Search Australian and New Zealand case law");
+    expect(help).toContain("Usage:");
+    expect(help).toContain("Examples:");
+    expect(help).toContain("--limit");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run src/test/unit/cli-help.test.ts
+```
+
+Expected: FAIL because `src/commands/help.ts` does not exist.
+
+- [ ] **Step 3: Create `src/commands/help.ts`**
+
+```ts
+import { COMMAND_CONTRACTS } from "./contracts.js";
+import type { CommandContract } from "./types.js";
+
+const GROUPS = [
+  ["search", "Search cases, legislation, citations, and local modules"],
+  ["cite", "Resolve, format, cache, and list citations"],
+  ["corpus", "Inspect installed local data modules and future corpora"],
+  ["graph", "Inspect local relationship data and future graph traces"],
+  ["source", "Fetch or inspect source documents"],
+  ["mcp", "Run and inspect MCP integration"],
+  ["doctor", "Diagnose configuration and capabilities"],
+] as const;
+
+export function renderTopLevelHelp(): string {
+  const lines = [
+    "jurisd - source-backed Australian legal research",
+    "",
+    "Usage:",
+    "  jurisd <command> [arguments] [flags]",
+    "  jurisd help <topic>",
+    "  jurisd mcp serve",
+    "",
+    "Common groups:",
+    ...GROUPS.map(([name, summary]) => `  ${name.padEnd(10)} ${summary}`),
+    "",
+    "Compatibility aliases:",
+    "  Existing flat commands such as search-cases and format-citation remain available.",
+    "",
+    "Run `jurisd help <topic>` or `jurisd <command> --help` for details.",
+  ];
+  return lines.join("\n");
+}
+
+export function renderCommandHelp(contract: CommandContract): string {
+  const cli = contract.adapters.cli;
+  const usage = contract.synopsis;
+  const flagLines = contract.flags.length
+    ? contract.flags.map((flag) => `  --${flag.name.padEnd(18)} ${flag.summary}`)
+    : ["  (none)"];
+  const argLines = contract.arguments.length
+    ? contract.arguments.map((arg) => `  ${arg.name.padEnd(20)} ${arg.summary}`)
+    : ["  (none)"];
+  const exampleLines = contract.examples.length ? contract.examples.map((example) => `  ${example}`) : ["  (none)"];
+
+  return [
+    contract.summary,
+    "",
+    "Usage:",
+    `  ${usage}`,
+    "",
+    "Arguments:",
+    ...argLines,
+    "",
+    "Flags:",
+    ...flagLines,
+    "",
+    "Examples:",
+    ...exampleLines,
+    "",
+    "Metadata:",
+    `  command id: ${contract.id}`,
+    `  side effect: ${contract.sideEffectClass}`,
+    `  result: ${contract.resultContract}`,
+    cli.aliases.length ? `  aliases: ${cli.aliases.join(", ")}` : "  aliases: (none)",
+  ].join("\n");
+}
+
+export function renderCommandList(): string {
+  return COMMAND_CONTRACTS
+    .filter((contract) => contract.adapters.cli.enabled)
+    .map((contract) => `${contract.adapters.cli.canonicalName ?? contract.id}: ${contract.summary}`)
+    .sort()
+    .join("\n");
+}
+```
+
+- [ ] **Step 4: Wire help into `src/cli.ts`**
+
+Import:
+
+```ts
+import { renderCommandHelp, renderCommandList, renderTopLevelHelp } from "./commands/help.js";
+import { getCommandContractByCliName } from "./commands/contracts.js";
+```
+
+Update `printHelp()` to use:
+
+```ts
+function printHelp(): void {
+  console.error(renderTopLevelHelp());
+}
+```
+
+Add handling in `runCli()` after `if (command === "help") {` logic. Replace the current help branch with:
+
+```ts
+if (command === "help") {
+  const topic = rest[0];
+  if (!topic) {
+    console.error(renderTopLevelHelp());
+  } else if (topic === "commands") {
+    console.error(renderCommandList());
+  } else {
+    const contract = getCommandContractByCliName(topic);
+    console.error(contract ? renderCommandHelp(contract) : `unknown help topic: ${topic}`);
+    if (!contract) process.exitCode = 2;
+  }
+  if (process.exitCode !== 2) process.exitCode = 0;
+  return true;
+}
+```
+
+Also before executing a tool command, support per-command help:
+
+```ts
+if (contract && (rest.includes("--help") || rest.includes("-h"))) {
+  console.error(renderCommandHelp(contract));
+  process.exitCode = 0;
+  return true;
+}
+```
+
+- [ ] **Step 5: Run help and CLI tests**
+
+```bash
+npx vitest run src/test/unit/cli-help.test.ts src/test/unit/cli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 5**
+
+```bash
+git add src/commands/help.ts src/cli.ts src/test/unit/cli-help.test.ts
+git commit -m "feat: render CLI help from command contracts"
+```
+
+---
+
+## Task 6: Add docs skeleton and security checklist
+
+**Files:**
+
+- Create: `docs/CLI.md`
+- Create: `docs/SECURITY-AUTHORITY.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Create `docs/CLI.md`**
+
+```markdown
+# jurisd CLI guide
+
+jurisd is a source-backed Australian legal research tool with MCP integration and a growing CLI surface.
+
+This guide documents the Foundation PR 1 CLI shape. It does not claim corpus import, vector search, graph traversal, Evidence Pack export, Isaacus integration, or agentic TUI functionality is implemented yet.
+
+## Current modes
+
+```bash
+jurisd
+```
+
+Starts the MCP server unless a CLI command handles the arguments first.
+
+```bash
+jurisd help
+jurisd help commands
+jurisd search-cases "native title"
+jurisd format-citation "Mabo v Queensland (No 2)" --neutral-citation "[1992] HCA 23"
+```
+
+## Command groups
+
+The long-term CLI is grouped by task:
+
+| Group | Purpose | Status |
+|---|---|---|
+| `search` | Search cases, legislation, citations, and local modules | Foundation metadata only |
+| `cite` | Resolve, format, cache, and list citations | Foundation metadata only |
+| `corpus` | Inspect local modules and future corpora | Foundation metadata only |
+| `graph` | Future relationship tracing and closed-world graph queries | Not implemented |
+| `review` | Future review-state workflow | Not implemented |
+| `enrich` | Future provider-backed enrichment jobs | Not implemented |
+| `export` | Future source-backed exports and Evidence Packs | Not implemented |
+| `mcp` | MCP server and compatibility inspection | Partially implemented by server startup |
+| `doctor` | Future capability and degradation diagnostics | Not implemented |
+| `tui` | Future terminal workbench | Not implemented in Foundation PR 1 |
+
+## Compatibility aliases
+
+Existing flat commands remain available during the foundation work, including:
+
+- `search-cases`
+- `search-legislation`
+- `format-citation`
+- `resolve-citation`
+- `get-provision`
+- `semantic-search-local`
+
+## Output rules
+
+- stdout is primary output.
+- stderr is diagnostics and help text.
+- JSON output must remain valid JSON.
+- Human output is not a stable parsing contract.
+
+## Exit codes
+
+| Code | Meaning |
+|---:|---|
+| 0 | success |
+| 1 | general failure |
+| 2 | usage or validation error |
+| 3 | no results |
+| 4 | source unavailable |
+| 5 | auth failure |
+| 6 | network failure |
+| 7 | parse or citation resolution failure |
+| 8 | partial success |
+| 9 | unsafe operation refused |
+| 10 | configuration error |
+| 11 | internal error |
+| 130 | interrupted |
+```
+
+- [ ] **Step 2: Create `docs/SECURITY-AUTHORITY.md`**
+
+```markdown
+# Security and authority model
+
+This file records the Foundation PR 1 security posture for jurisd command contracts, CLI routing, and MCP compatibility.
+
+## Trust boundaries
+
+- CLI arguments are untrusted.
+- MCP inputs are untrusted.
+- Future TUI input is untrusted.
+- Source text and provider responses are untrusted display data.
+- Completion candidates and descriptions are code-adjacent output and must be treated as untrusted.
+- Credentials are configuration secrets.
+
+## Side-effect classes
+
+Commands declare one side-effect class:
+
+- `read_only_query`
+- `local_metadata_read`
+- `network_read`
+- `credential_dependent_read`
+- `corpus_write`
+- `graph_write`
+- `review_state_write`
+- `export_write`
+- `filesystem_write`
+- `network_write`
+- `destructive_admin`
+
+## MCP exposure
+
+MCP exposure is curated. Do not expose operator, install, update, destructive, filesystem-write, or network-write commands over MCP unless a later authority decision explicitly allows it.
+
+## Terminal safety
+
+Untrusted text must not produce terminal control effects. Renderers must strip or neutralise unsafe ANSI, OSC, BEL, carriage returns, title changes, bidi controls, and other unsafe control characters before rendering source/provider text.
+
+## Credential handling
+
+Credentials must never appear in:
+
+- command arguments
+- logs
+- TUI transcript
+- MCP result metadata
+- Evidence Packs
+- generated docs/examples
+- debug output except in redacted form
+
+## Foundation PR 1 checklist
+
+- [ ] command contracts classify side effects
+- [ ] MCP compatibility set is pinned
+- [ ] CLI help does not expose secrets or provider credentials
+- [ ] stdout/stderr behaviour is tested
+- [ ] no new shell execution path is introduced
+- [ ] docs do not claim unbuilt graph, vector, corpus, or provider features
+```
+
+- [ ] **Step 3: Update `README.md` with links**
+
+Add a short section near existing CLI/module documentation:
+
+```markdown
+## CLI foundation and compatibility
+
+jurisd keeps the MCP server as the compatibility surface while the CLI is being reorganised around task-oriented command contracts.
+
+- CLI guide: [docs/CLI.md](docs/CLI.md)
+- MCP compatibility reference: [docs/MCP-COMPATIBILITY.md](docs/MCP-COMPATIBILITY.md)
+- Security and authority model: [docs/SECURITY-AUTHORITY.md](docs/SECURITY-AUTHORITY.md)
+
+Existing flat CLI commands remain available during the foundation work.
+```
+
+- [ ] **Step 4: Verify docs**
+
+```bash
+grep -q "Foundation PR 1" docs/CLI.md
+grep -q "MCP exposure is curated" docs/SECURITY-AUTHORITY.md
+grep -q "CLI foundation and compatibility" README.md
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 5: Commit Task 6**
+
+```bash
+git add docs/CLI.md docs/SECURITY-AUTHORITY.md README.md
+git commit -m "docs: add CLI foundation and authority guides"
+```
+
+---
+
+## Task 7: Final integration tests and full verification
+
+**Files:**
+
+- Modify only files needed to fix failures found during verification.
+
+- [ ] **Step 1: Run focused unit tests**
+
+```bash
+npx vitest run \
+  src/test/unit/command-contracts.test.ts \
+  src/test/unit/mcp-compatibility.test.ts \
+  src/test/unit/cli-help.test.ts \
+  src/test/unit/cli.test.ts \
+  src/test/unit/tool-surface.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run build**
+
+```bash
+npm run build
+```
+
+Expected: TypeScript build succeeds and `dist/` is generated.
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Run lint and format check**
+
+```bash
+npm run lint
+npm run format:check
+```
+
+Expected: both pass.
+
+- [ ] **Step 5: Manual CLI smoke checks**
+
+After build:
+
+```bash
+node dist/index.js help
+node dist/index.js help search-cases
+node dist/index.js search-cases "native title" --limit 1
+node dist/index.js get-provision
+```
+
+Expected:
+
+- `help` prints top-level help to stderr and exits 0.
+- `help search-cases` prints command help to stderr and exits 0.
+- `search-cases` runs through existing behaviour. Network/source failures are acceptable if represented by existing error handling.
+- `get-provision` with no args exits 2 and prints usage or command error.
+
+- [ ] **Step 6: Verify unrelated files remain untouched**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only intended files are modified. Pre-existing files may still appear:
+
+```text
+ M build.sh
+?? docs/DOGFOODING.md
+?? podman-build.sh
+```
+
+Do not stage those files.
+
+- [ ] **Step 7: Commit verification fixes if any**
+
+If fixes were required:
+
+```bash
+git add <changed implementation/test/doc files only>
+git commit -m "fix: stabilise CLI foundation checks"
+```
+
+If no fixes were required, do not create an empty commit.
+
+---
+
+## Task 8: Team leader final review and PR preparation
+
+**Files:**
+
+- No required changes unless final review finds issues.
+
+- [ ] **Step 1: Review commit history**
+
+```bash
+git log --oneline origin/$(git branch --show-current)..HEAD
+```
+
+Expected: commits are focused and ordered by task.
+
+- [ ] **Step 2: Review diff summary**
+
+```bash
+git diff --stat origin/$(git branch --show-current)..HEAD
+```
+
+Expected: only Foundation PR 1 files are present. No corpus, graph backend, vector, Isaacus, Evidence Pack, or full TUI implementation appears.
+
+- [ ] **Step 3: Re-run final verification**
+
+```bash
+npm run build
+npm test
+npm run lint
+npm run format:check
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Prepare PR body**
+
+Use this body structure:
+
+```markdown
+## Summary
+
+- Added command contract foundation for CLI/docs/future adapters.
+- Preserved current MCP compatibility surface and pinned it with tests/reference docs.
+- Reworked CLI routing/help to derive from command metadata.
+- Added repo conventions, CLI guide, and security/authority checklist.
+
+## Scope
+
+This is Foundation PR 1 only. It does not implement corpus storage, vector indexing, graph backends, Isaacus integration, Evidence Packs, completions, or full TUI behaviour.
+
+## Verification
+
+- [ ] npm run build
+- [ ] npm test
+- [ ] npm run lint
+- [ ] npm run format:check
+
+## Compatibility
+
+Existing 15 MCP tool names remain stable. Existing flat CLI commands remain available as compatibility aliases.
+
+## Security notes
+
+- No new shell execution path.
+- MCP exposure remains curated.
+- Credentials remain configuration-only and are not emitted in docs/examples.
+```
+
+- [ ] **Step 5: Open PR when requested by Russ**
+
+Do not push or open a PR unless Russ has asked for it in the execution session.
+
+---
+
+## Self-review notes
+
+Spec coverage:
+
+- Repo conventions covered by Task 1.
+- MCP compatibility preservation covered by Task 2.
+- Command contract architecture covered by Task 3.
+- CLI skeleton and help covered by Tasks 4 and 5.
+- Docs skeleton covered by Task 6.
+- Security checklist covered by Tasks 1 and 6.
+- Full verification covered by Task 7.
+- Team leader handoff covered by Task 8.
+
+Intentionally deferred:
+
+- Shell completions, Foundation PR 2.
+- TUI scaffold, Foundation PR 3.
+- Natural-language agent planner, later PR.
+- CorpusStore, source import, vector search, graph backend, Evidence Pack, Isaacus adapters, later stages.
+
+No task should modify the pre-existing unrelated files `build.sh`, `docs/DOGFOODING.md`, or `podman-build.sh`.

--- a/docs/superpowers/specs/2026-06-16-cli-tui-legal-workbench-design.md
+++ b/docs/superpowers/specs/2026-06-16-cli-tui-legal-workbench-design.md
@@ -1,0 +1,1061 @@
+# jurisd CLI/TUI legal reasoning workbench design
+
+Date: 2026-06-16
+Status: approved design, pending implementation plan
+Scope: jurisd CLI, TUI, MCP adapter foundations, command contracts, help, completions, security conventions, and north-star architecture for local corpora, vector recall, graph traversal, provider enrichment, and source-backed legal reasoning.
+
+## 1. Product stance
+
+jurisd is a source-backed Australian legal research and provenance instrument over a governed command surface. It supports legal research, source verification and relationship tracing for human review. It is not a chatbot, oracle, AI companion or autonomous legal advice system.
+
+The north star is a terminal workbench for legal reasoning, comparable in operating style to Claude Code, but over legal corpora rather than source code repositories.
+
+Plain model:
+
+1. Import legal sources, matter documents, PDFs, HTML, legislation, case law, notes, or source bundles.
+2. Preserve originals in custody with content hashes and provenance.
+3. Extract document structure, source spans, paragraphs, headings, provisions, citations, judges, parties, courts, and defined terms.
+4. Create chunks and embeddings for source-backed semantic recall.
+5. Build and query legal relationship data, including citation paths, source trails, authority trails, matter maps, and reviewable graph edges.
+6. Trace every result, relationship, enrichment, and generated claim back to source spans or label it as proposed, unresolved, degraded, or rejected.
+7. Let humans and agents search, inspect, trace, review, enrich, write, export, and maintain the local legal knowledge base.
+
+Core invariant:
+
+> No source span, no trusted legal claim.
+
+Vector search is recall, not legal authority. Graph traversal is a map over stored relationships, not a proof of law. External enrichment is candidate generation unless accepted through deterministic gates or review.
+
+## 2. WorkingMem terminology alignment
+
+The design uses WorkingMem terminology where applicable.
+
+Use:
+
+- command contract registry with authority metadata
+- typed command contract
+- authority-aware execution service layer
+- CLI adapter
+- MCP adapter
+- TUI adapter
+- future local-server or web adapter
+- renderer for output formats only
+- source span
+- source-span-backed result block
+- source artifact
+- provenance tracing
+- legal relationship block
+- relationship claim
+- closed-world read
+- review state
+- Evidence Pack, only for externally verifiable proof bundles
+
+Avoid or qualify:
+
+- unqualified registry
+- MCP renderer
+- TUI renderer, where the TUI is interactive
+- citation as the generic provenance anchor
+- source text as the trust anchor
+- unqualified authority
+- unqualified verified
+- user-facing numeric confidence as legal confidence
+- same_source_as unless identity layers are defined
+- free, premium, basic, or pro provider tier language
+
+Canonical product sentence:
+
+> jurisd is a source-backed Australian legal research and provenance instrument over a governed command surface. It supports legal research, source verification and relationship tracing for human review. It is not a chatbot, oracle, AI companion or autonomous legal advice system.
+
+## 3. Command architecture
+
+Commands are defined by stable typed command contracts. CLI, MCP, TUI, and future local-server or web surfaces are adapters over those contracts. Execution is routed through an authority-aware service layer that performs validation, capability checks, side-effect checks, provenance capture, review gating, audit recording, and typed result production.
+
+Preferred architecture:
+
+```text
+Command contract registry with authority metadata
+→ Authority-aware execution service layer
+→ Application services
+→ CLI / MCP / TUI / local-server adapters
+→ Human / JSON / NDJSON / Plain / Markdown renderers
+→ Generated help / completions / docs / tests
+```
+
+Internal command ids are stable identifiers. CLI commands, MCP tool names, and TUI labels are adapter-specific aliases.
+
+Example mapping:
+
+```text
+command id: search.cases
+CLI:        jurisd search cases
+MCP:        search_cases
+TUI:        Search cases
+Docs:       /commands/search/cases
+```
+
+MCP names remain stable `snake_case`. CLI names use task-oriented command words. TUI labels are human-readable.
+
+### 3.1 Command contract fields
+
+Every public command contract must declare:
+
+- stable command id
+- aliases
+- synopsis
+- summary
+- description
+- arguments
+- flags
+- stdin mode
+- output modes
+- examples
+- exit codes
+- validation schema
+- completion provider metadata
+- MCP mapping, if exposed
+- TUI metadata, if exposed
+- docs anchor
+- stability level
+- side-effect class
+- dangerousness
+- auth, network, source, and cache requirements
+- terminal safety policy
+- path and URL policy
+- capability gates
+- result contract
+
+Missing required metadata fails tests.
+
+### 3.2 Adapter eligibility metadata
+
+Each command contract must record adapter eligibility and side-effect metadata.
+
+Example:
+
+```yaml
+command_id: search.cases
+cli_alias: jurisd search cases
+mcp_tool: search_cases
+tui_label: Search cases
+adapters:
+  cli: true
+  mcp: true
+  tui: true
+side_effect_class: read_only_query
+confirmation_required: false
+filesystem_write: false
+network_write: false
+admin_only: false
+credential_dependent: false
+capability_gates: []
+result_contract: legal_search_results.v1
+```
+
+## 4. MCP exposure rule
+
+MCP exposure is curated. Not every internal command becomes an MCP tool.
+
+MCP tools are limited to stable, frequent, externally useful query and review intents. Variants should be consolidated behind `mode`, `op`, `action`, or `by` parameters where they share intent. Dedicated MCP tools are reserved for crisp, frequent, distinct intents.
+
+Operator, install, update, fetch, destructive, filesystem-write, and network-write commands are CLI-only unless a later decision explicitly allows them under an authority contract.
+
+Existing MCP tool names and schemas must remain compatible unless explicitly documented as a breaking change. Current 15 MCP tools stay stable during the first CLI/TUI foundation PR.
+
+Safe future MCP workbench tools may include:
+
+- `search_sources`
+- `get_source_span`
+- `trace_claim`
+- `inspect_node`
+- `query_graph_closed_world`
+- `propose_edge`
+- `review_item`
+- `resolve_citation`
+- `import_source`, only with authority and audit controls
+- `corpus_status`
+- `export_evidence_pack`
+
+MCP must call the same application services as CLI and TUI. It must not bypass review, provenance, capability, or authority checks.
+
+## 5. CLI product model
+
+The CLI is workflow-shaped, not a raw MCP tool dump.
+
+Recommended top-level groups:
+
+```text
+jurisd sources
+jurisd corpus
+jurisd search
+jurisd graph
+jurisd review
+jurisd enrich
+jurisd export
+jurisd mcp
+jurisd doctor
+jurisd completion
+jurisd tui
+```
+
+Useful aliases:
+
+```text
+jurisd import   -> jurisd sources import
+jurisd trace    -> jurisd graph trace
+jurisd inspect  -> object inspection
+jurisd status   -> jurisd corpus status
+```
+
+Existing flat tool-parity commands should remain as compatibility aliases initially. Help should lead users toward the grouped workflow commands.
+
+### 5.1 Help contract
+
+Top-level help must be short, task-oriented, and example-driven. Per-command help must include:
+
+- one-line purpose
+- required arguments
+- optional flags
+- defaults
+- accepted values
+- examples
+- output modes
+- exit codes
+- related commands
+- failure examples
+- security or source caveats where relevant
+
+Help entry points:
+
+```text
+jurisd
+jurisd help
+jurisd help search
+jurisd search --help
+jurisd search cases --help
+jurisd help examples
+jurisd help outputs
+jurisd help exit-codes
+```
+
+Generated reference is allowed. Guidance, tutorials, legal workflows, troubleshooting, and security model docs must be authored.
+
+### 5.2 Output contract
+
+Global output modes:
+
+```text
+--format human|json|ndjson|plain|markdown
+--json
+--plain
+--no-color
+--quiet
+--verbose
+--debug
+--timeout
+```
+
+Rules:
+
+- stdout is primary output only
+- stderr is diagnostics and errors only
+- JSON mode emits valid JSON only
+- JSON and NDJSON contain no colour, progress bars, terminal decoration, or prose prefixes
+- human output is not a parsing contract
+- every machine output includes a schema version
+
+Stable exit codes:
+
+```text
+0   success
+1   general failure
+2   usage or validation error
+3   no results
+4   source unavailable
+5   auth failure
+6   network failure
+7   parse or citation resolution failure
+8   partial success
+9   unsafe operation refused
+10  configuration error
+11  internal error
+130 interrupted
+```
+
+Errors must be actionable. They should explain what failed, expected values or shape, whether anything executed, and one concrete fix. Raw zod dumps and stack traces are debug-only.
+
+## 6. TUI product model
+
+The TUI is an agentic legal reasoning workbench, not a passive renderer and not a chatbot.
+
+The TUI is an adapter and operating surface over the same command contracts and application services as the CLI and MCP.
+
+Core areas:
+
+- Sources
+- Corpus
+- Search
+- Graph
+- Review
+- Enrich
+- Exports
+- Doctor
+
+Core panes:
+
+- corpus and source tree
+- source text with highlighted spans
+- search and recall results
+- graph or path view
+- inspector and provenance pane
+- review queue
+- reasoning trace
+- status and degradation strip
+- command palette
+
+Plain action labels:
+
+- Add sources
+- Find related passages
+- Trace this claim
+- Show why this is linked
+- Open source span
+- Mark as accepted
+- Mark as disputed
+- Export evidence pack
+- Check system health
+
+### 6.1 Agentic TUI
+
+The TUI includes a built-in research agent. Natural language is the control surface. Source-backed commands, provenance, review state, and typed result blocks are the execution surface.
+
+The user can type:
+
+```text
+Find the main authorities on extinguishment of native title and show how they relate to Mabo.
+```
+
+The agent may plan and run governed commands:
+
+1. identify or ask for active corpus
+2. search lexical and semantic indexes
+3. resolve citations
+4. inspect source spans
+5. traverse accepted graph edges
+6. propose candidate relationships
+7. show authority trails
+8. ask before mutating graph or review state
+9. export source-backed notes or Evidence Packs
+
+The agent is not a separate backend. It operates through the command contract registry and authority-aware execution service.
+
+Read-only operations may run automatically within the active corpus scope:
+
+- local search
+- semantic recall
+- source-span inspection
+- citation resolution
+- accepted graph traversal
+- provider capability checks
+- provenance tracing
+- source-backed summary of retrieved spans
+
+Confirmation is required for:
+
+- imports
+- external network fetches not already configured as safe source providers
+- enrichment jobs
+- embedding or index rebuilds
+- graph build, rebuild, repair, or mutation
+- review-state changes
+- exports
+- native graph queries
+- credentialed provider calls with cost or data-boundary implications
+
+Agent plans must be visible. Running plans must be interruptible. Every agent action is recorded as command executions plus provenance or audit events where relevant.
+
+### 6.2 TUI terminal behaviour
+
+Default TUI preserves native terminal scrollback. It does not use alternate screen by default. Completed output is stable, selectable, and copy-friendly.
+
+The TUI must honour:
+
+- `NO_COLOR`
+- `FORCE_COLOR`
+- `TERM=dumb`
+- CI environments
+- screen-reader mode where supported
+- narrow terminal widths
+- keyboard-only operation
+
+Colour never carries meaning alone. Use labels such as `OK`, `WARN`, `ERROR`, `SOURCE`, `CANCELLED`, `DEGRADED`, and `NEEDS REVIEW`.
+
+## 7. Source, corpus, vector, and graph architecture
+
+jurisd is built around a canonical source-backed corpus. Vector and graph systems are replaceable projections.
+
+Plain architecture:
+
+```text
+SourceStore              raw custody
+CorpusStore              canonical local truth
+Parser/ExtractorProvider document-interior extraction
+VectorIndexProvider      semantic recall
+GraphProvider            graph projection and traversal
+LegalDomainProvider      enrichment, embeddings, rerank, extractive QA, classification
+ReviewService            review-state transitions
+ProvenanceService        event and audit trail
+TraceService             explain why a result exists
+ExportService            Evidence Packs and outputs
+CLI / TUI / MCP          adapters over the same services
+```
+
+Key rule:
+
+```text
+CorpusStore = truth
+VectorIndexProvider = recall accelerator
+GraphProvider = traversal accelerator
+LegalDomainProvider = enrichment and candidate generator
+```
+
+### 7.1 SourceSpan invariant
+
+`SourceSpan` is the mandatory join key across the system.
+
+A source span connects:
+
+- source document
+- document version
+- paragraph, provision, heading, page, or pinpoint
+- chunk
+- embedding
+- vector hit
+- graph node
+- graph edge
+- citation relationship
+- extracted fact
+- enrichment result
+- review item
+- generated answer fragment
+- Evidence Pack entry
+- provenance event
+
+Every legal assertion is either traceable to source spans or explicitly marked as proposed, unresolved, inferred, degraded, or rejected.
+
+### 7.2 Canonical local data model
+
+Minimum north-star concepts:
+
+- corpus
+- source_document
+- document_version
+- source_blob
+- source_span
+- segment
+- chunk
+- chunk_span
+- embedding_job
+- embedding_record
+- entity
+- citation
+- relationship
+- graph_node
+- graph_edge
+- review_item
+- provenance_event
+- audit_event
+- import_job
+- enrichment_job
+- provider_capability
+- unmatched_citation
+- export_bundle
+
+The first CLI/TUI foundation PR does not need to implement this model. It must avoid architectural choices that block it.
+
+### 7.3 Local and production storage direction
+
+Preferred local direction, subject to spikes:
+
+- DuckDB as local analytical substrate where stable and packageable
+- DuckPGQ as preferred local graph-query candidate, subject to maturity and packaging verification
+- SQLite adjacency tables as safe fallback baseline
+- sqlite-vec, DuckDB vector extension, or local pgvector profile for vector recall, selected by verification
+
+Production direction:
+
+- object storage or CAS for source custody
+- PostgreSQL for canonical store
+- pgvector-class retrieval by default
+- graph backend behind GraphProvider
+- queue workers for parse, embed, graph, enrichment, and export jobs
+- tenant, matter, classification, and compartment boundaries
+- audit streams
+
+No specialised vector database or graph service becomes mandatory until measured requirements justify it.
+
+### 7.4 GraphProvider
+
+GraphProvider owns graph projection and traversal, not canonical legal truth.
+
+Required operations:
+
+- upsert_node
+- upsert_edge
+- get_node
+- get_edge
+- neighbours
+- paths
+- subgraph
+- temporal_as_of
+- explain_path
+- closed_world_query
+- capabilities
+- health
+- degradation
+
+Potential backends:
+
+- DuckDB plus DuckPGQ
+- LadybugDB
+- SQLite adjacency tables
+- PostgreSQL adjacency tables
+- FalkorDB
+- Graphiti
+- Neo4j
+- RDF/SPARQL backend
+- production custom backend
+
+DuckDB plus DuckPGQ is the leading local graph-query candidate because it aligns with embedded analytics, Parquet data modules, graph-over-table querying, and export workflows. LadybugDB is a candidate embedded property-graph backend and likely Kuzu successor, subject to verification. Graphiti is a candidate temporal graph-memory provider, not the architecture.
+
+### 7.5 Graph query language
+
+Do not make Cypher the canonical internal query language.
+
+Use three layers:
+
+1. guided commands for users and agents
+2. portable typed graph query contract for internals, TUI, MCP, and tests
+3. native backend query for expert mode
+
+Guided commands:
+
+```text
+jurisd graph neighbours <node>
+jurisd graph path <from> <to>
+jurisd graph trace <claim-or-node>
+jurisd graph inspect <node-or-edge>
+jurisd graph subgraph <node>
+jurisd graph as-of <date>
+```
+
+Native expert mode:
+
+```text
+jurisd graph query --language pgq '...'
+jurisd graph query --language cypher '...'
+jurisd graph query --language sparql '...'
+```
+
+Native query remains policy-wrapped. It must not bypass corpus scope, review-state policy, closed-world mode, time slicing, source-span requirements, or audit controls.
+
+### 7.6 Closed-world graph reads
+
+Graph reads used for legal reasoning are closed-world by default.
+
+A graph query is scoped by:
+
+- corpus
+- matter, where applicable
+- compartment or classification
+- review-state policy
+- time slice
+- permitted edge types
+- provider capability state
+- degradation state
+
+If no edge is stored, jurisd reports that no stored relationship was found in the current graph. It must not imply that the relationship is false in law.
+
+Inferred or provider-proposed edges are candidates until reviewed.
+
+### 7.7 Vector search
+
+Vector search is semantic source recall, not authority.
+
+A vector or hybrid hit returns:
+
+- chunk_id
+- source_span_ids
+- document_id
+- document_version_id
+- corpus_id
+- citation or pinpoint
+- snippet
+- vector score
+- lexical score, if hybrid
+- rerank score, if reranked
+- embedding provider
+- embedding model
+- source hash
+- review state
+- classification or compartment
+- degradation flags
+
+The user-facing label should be “Find related source passages”, not “ask the vector database”.
+
+## 8. Isaacus, ILDGS, Blackstone Graph, and provider pluggability
+
+jurisd is Isaacus-aligned by default and provider-pluggable by contract.
+
+Isaacus alignment is a first-class design constraint because Isaacus/Kanon appears to be the strongest Australian legal-domain provider path. That alignment must not become hard coupling.
+
+### 8.1 Legal-domain provider capabilities
+
+A LegalDomainProvider may supply:
+
+- document-interior enrichment
+- entity extraction
+- legal classification
+- embeddings
+- reranking
+- extractive Q&A
+- relationship extraction
+- world-layer entity or relationship mapping
+- graph traversal or graph service access
+
+Isaacus may provide several of these in future. Self-hosted legal models, general embeddings, local deterministic parsers, and production graph services must remain valid alternatives.
+
+### 8.2 Layer model
+
+```text
+Document-interior layer:
+  ILDGS-compatible spans, segments, cross-references, external-document mentions
+
+World layer:
+  Blackstone Graph-compatible legal and real-world entity taxonomy where verified
+
+jurisd trust envelope:
+  source span, provenance, review state, degradation, audit, correction path
+
+Provider/backend layer:
+  Isaacus API/MCP, self-hosted models, local data modules, Graphiti, DuckDB, production graph backend
+```
+
+### 8.3 Provider schema namespacing
+
+Provider-specific fields are namespaced and versioned:
+
+```ts
+providerSchema: {
+  provider: "isaacus";
+  schema: "ildgs" | "blackstone-graph";
+  version: string;
+  type: string;
+}
+```
+
+jurisd should use ILDGS and Blackstone-compatible terminology where schemas are available and verified. Do not invent competing legal ontology names where a verified provider term exists. Add local provenance and review metadata by wrapping provider terms, not by renaming the legal concept.
+
+### 8.4 Provider labels
+
+Use capability labels:
+
+- baseline
+- Isaacus-enhanced
+- self-hosted legal model
+- domain-specialised
+- provider-unavailable
+- capability-missing
+
+Do not use free, premium, basic, or pro as legal capability language.
+
+### 8.5 Capability gates
+
+No command may require Isaacus unless explicitly labelled Isaacus-required. Commands declare capability gates, for example `requires: relationshipExtraction`.
+
+If a capability is absent, return typed `capability_missing`, not silent fallback.
+
+## 9. Legal relationship blocks
+
+Use “legal relationship blocks”, not “citation/provision relationship graph blocks”.
+
+Legal relationship blocks represent source-span-backed relationship claims between legal sources, provisions, documents, facts, issues, arguments, parties, courts, or source spans.
+
+Every node and edge must carry:
+
+- provenance
+- evidence or source span where available
+- extraction method
+- confidence or corroboration state
+- review state
+- correction path
+
+### 9.1 Extract then resolve
+
+Extract then resolve.
+
+Extracted mentions, citations, provisions, pinpoints, treatment strings, and cross-references are captured first. Resolution to canonical legal entities occurs in a separate audited step. Unresolved, ambiguous, malformed, unsupported-scheme, and no-match outcomes are first-class typed results. They must not be guessed, silently dropped, or converted into asserted relationships.
+
+### 9.2 Relationship layers
+
+Citation/document graph:
+
+- cites
+- considers
+- cited_by as inverse query projection, not usually a stored edge
+
+Legal treatment graph:
+
+- applied
+- followed
+- not_followed
+- distinguished
+- approved
+- overruled
+- interpreted
+- applies_authority, if using normalised canonical labels
+
+Matter/fact graph:
+
+- supports
+- contradicts
+- mentions
+- occurred_before
+- filed_in
+
+Structure graph:
+
+- contains
+- part_of
+- act_provision
+- internal_crossref
+- has_source_span
+
+Legal treatment edges must retain the raw upstream treatment string where available. Editorial-grade treatment signals must be provider-derived, rule-derived, or human-reviewed before accepted use.
+
+## 10. Typed result blocks and renderers
+
+Handlers return typed result blocks, not opaque strings.
+
+Renderers are output projections over typed result blocks. Renderers may format, order, hide, or summarise fields according to output mode, but must not invent confidence, alter provenance, collapse review state, or change command semantics.
+
+Renderers:
+
+- human
+- json
+- ndjson
+- plain
+- markdown
+
+MCP is an adapter, not a renderer. TUI is an interactive adapter and research surface, not merely a renderer.
+
+### 10.1 Required result block envelope
+
+Legal result blocks should carry, where available:
+
+- command_id
+- result_id
+- block_type
+- generated_vs_source
+- source_kind
+- provider
+- module_name
+- module_version
+- snapshot_date
+- observed_at
+- retrieved_at
+- source_url
+- content_hash
+- span_locator
+- char_start
+- char_end
+- pinpoint
+- extraction_or_query_method
+- confidence_label
+- corroboration_state
+- review_state
+- provenance_event_id
+- audit_event_id
+- correction_path
+- degradation_state
+- degradation_note
+
+Legal result blocks must carry provenance sufficient to trace the result to a source span, provider record, module version, or explicit degraded/refused state.
+
+## 11. Review, confidence, and generated content
+
+Review states:
+
+- raw
+- extracted
+- proposed
+- needs_review
+- accepted
+- corrected
+- rejected
+- disputed
+- superseded
+- stale
+- quarantined
+- unresolved
+
+MVP may begin with:
+
+- proposed
+- accepted
+- rejected
+- disputed
+- superseded
+- unresolved
+
+Confidence/corroboration terms:
+
+- confidence_label
+- confidence_band
+- corroboration_state
+- needs_review
+- low_confidence_extraction
+- single_source_inference
+- multi_source_corroborated
+- conflicting_evidence
+- primary_source_confirmed
+
+Numeric confidence is not shown as legal confidence by default. Numeric values may appear only when they are explicitly retrieval scores, deterministic facet scores, or calibrated metrics with documented semantics.
+
+Generated summaries, answers, tags, relationship edges, extracted citations, and graph mutations are proposals unless accepted by deterministic gates or review. Generated output is not verified output. Source-backed does not mean legally correct.
+
+## 12. Security, authority, and mutation boundaries
+
+Every command declares a side-effect class:
+
+- read_only_query
+- local_metadata_read
+- network_read
+- credential_dependent_read
+- corpus_write
+- graph_write
+- review_state_write
+- export_write
+- filesystem_write
+- network_write
+- destructive_admin
+
+The authority-aware execution service enforces:
+
+- command schema validation
+- active corpus or matter scope
+- permitted adapters
+- side-effect class
+- capability gates
+- credential gates
+- confirmation requirements
+- review-state policy
+- source-span requirement
+- audit and provenance event creation
+
+### 12.1 Confirmation rules
+
+No confirmation needed for local read-only search, source-span inspection, accepted graph traversal, provenance tracing, or doctor/capability checks.
+
+Confirmation required for imports, external network fetches, enrichment jobs, embedding or index rebuilds, graph build/rebuild/repair, review-state changes, exports, native graph queries, credentialed provider calls with cost or data-boundary implications, and destructive/admin operations.
+
+### 12.2 Terminal safety
+
+All untrusted text is hostile display input:
+
+- source text
+- provider responses
+- case names
+- court names
+- upstream errors
+- URLs
+- filenames
+- generated summaries
+
+Renderers must strip or neutralise ANSI escapes, OSC hyperlinks, BEL, carriage returns, terminal title changes, bidi controls, and unsafe control characters. JSON and NDJSON contain no terminal decoration.
+
+### 12.3 Credential rules
+
+Credentials are configuration secrets.
+
+They must never appear in command arguments, logs, TUI transcript, MCP result metadata, Evidence Packs, generated docs/examples, or debug output except in redacted form.
+
+JADE session cookies, Isaacus keys, provider keys, and graph backend credentials are credential-dependent capability gates, not product tiers.
+
+## 13. Evidence Packs and exports
+
+Evidence Packs are externally verifiable export bundles with proof material. Ordinary CLI/TUI/MCP responses are typed result blocks with provenance metadata, not Evidence Packs.
+
+An Evidence Pack contains:
+
+- source spans
+- hashes or content identifiers
+- document versions
+- graph nodes and edges used
+- review decisions
+- provenance events
+- provider and model versions
+- degradation notes
+- command and audit events
+
+An Evidence Pack proves what the system used, which sources were present, which policy and review state existed, and how an output was produced. It does not prove that a legal conclusion is correct.
+
+## 14. Shell completions
+
+Completions are generated from command metadata and trusted static values.
+
+Required shells:
+
+- bash
+- zsh
+- fish
+- PowerShell, if practical in the same PR, otherwise staged explicitly
+
+Completions must not perform network calls, execute tools, inspect untrusted project files, evaluate user-controlled text, or generate shell fragments from untrusted data.
+
+Shell-specific escaping tests must cover quotes, whitespace, newlines, command substitutions, dollar expansions, backticks, leading dashes, ANSI escapes, OSC sequences, and control characters.
+
+Completion install should print instructions or completion script content. It must not edit shell rc files by default.
+
+## 15. Documentation and contributor conventions
+
+Documentation is split into authored guidance and generated reference.
+
+Authored docs:
+
+- getting started
+- legal research workflows
+- CLI concepts
+- TUI workflow
+- MCP integration
+- config and cache
+- source custody and provenance model
+- security model
+- troubleshooting
+- migration notes
+
+Generated docs:
+
+- command reference
+- option reference
+- JSON schemas
+- MCP tool reference
+- completions docs
+- registry coverage tables
+
+Generated sections must have deterministic ordering and visible generated notices. CI must fail when generated docs or completions are stale.
+
+`AGENTS.md` should include:
+
+- project purpose
+- architecture map
+- generated-file rules
+- required tests
+- security constraints
+- docs rules
+- review standards
+- anti-slop rules
+- how to add a command once
+
+`CONTRIBUTING.md` should include:
+
+- local setup
+- test commands
+- registry change process
+- docs generation
+- snapshot review
+- security review triggers
+- changelog fragment rules
+- PR checklist
+
+## 16. First PR scope
+
+The first PR ships foundations only.
+
+Deliver:
+
+1. Repo conventions: `AGENTS.md`, strengthened `CONTRIBUTING.md`, rules for command contracts, generated docs, tests, security, and anti-slop examples.
+2. Command contract architecture: command contract registry with authority metadata, adapter metadata, side-effect classification, capability gates, result contract hooks, registry coverage tests.
+3. MCP compatibility preservation: existing 15 MCP tools remain stable, MCP names stay `snake_case`, no operator/admin commands exposed over MCP by default, compatibility tests prove behaviour is not broken.
+4. CLI foundation: grouped command UX, compatibility aliases for existing flat commands, per-command help, global help topics, stable exit codes, stdout/stderr rules, `--json`, `--plain`, `--no-color`, `--debug`, actionable errors.
+5. Shell completions: bash, zsh, fish, and PowerShell if practical, generated from metadata with shell-safe escaping tests.
+6. TUI foundation: `jurisd tui`, command palette, transcript/composer layout, slash commands, minimal natural-language planning boundary, and future pane placeholders.
+7. Docs: authored CLI guide, authored TUI guide, generated command reference, completion install docs, security and authority docs, architecture/north-star section.
+8. Security review artefact: committed checklist/report covering terminal injection, no-shell invariant, completion injection, credential redaction, MCP exposure, and authority boundaries.
+
+Explicitly do not build in the first PR:
+
+- full CorpusStore
+- DuckDB/DuckPGQ integration
+- LadybugDB integration
+- Graphiti integration
+- vector indexing
+- source import pipeline
+- Evidence Pack export
+- Isaacus provider integration
+- full agentic planner
+- graph visualisation
+- review queue persistence
+
+The first PR must make room for those features without pretending to ship them.
+
+## 17. Staging after the first PR
+
+Recommended stages:
+
+1. Source custody and CorpusStore.
+2. Parser/source spans and document-interior extraction.
+3. Lexical and semantic recall.
+4. GraphProvider with DuckDB/DuckPGQ or adjacency backend spike.
+5. Review workflow.
+6. Agentic TUI workbench.
+7. Evidence Pack export.
+8. MCP workbench tools.
+9. Isaacus and self-hosted provider adapters.
+10. Advanced graph and vector backends.
+
+## 18. Acceptance criteria for the first PR
+
+The first PR is acceptable only if:
+
+- command metadata is not duplicated by hand across MCP, CLI, TUI, docs, and completions
+- adding a command without required metadata fails tests
+- existing MCP tool names and schemas remain compatible
+- CLI help is useful, not schema-dump prose
+- CLI errors are actionable
+- stdout/stderr behaviour is documented and tested
+- completions are deterministic and shell-safe
+- TUI starts and exposes command palette/help
+- docs explain the north-star architecture without claiming v1 has all of it
+- security review is committed
+- full test, lint, and build pass
+
+## 19. Open verification items
+
+Before implementation of later graph/vector/provider stages, verify with current external research:
+
+- DuckDB + DuckPGQ packaging, TypeScript integration, maturity, persistence, and offline extension story
+- LadybugDB packaging, licence, persistence, TypeScript integration, and project maturity
+- Graphiti backend support, temporal semantics, provenance model, licensing, and operational maturity
+- sqlite-vec, DuckDB vector extensions, pgvector, pgvectorscale, VectorChord, LanceDB, Qdrant, and Weaviate trade-offs
+- Isaacus/Kanon Embedder, Reranker, Enricher, ILDGS, Blackstone Graph schema, access, licence, and Australian coverage
+- Docling, OCR, paragraph-preserving legal parsers, LegalDocML/Akoma Ntoso, and citation resolvers
+- terminal framework suitability for the TUI workbench model
+- MCP patterns for scoped, provenance-bearing, capability-aware tools
+
+## 20. Design decisions summary
+
+- jurisd is a terminal legal reasoning workbench, not a chatbot.
+- command contracts are the product contract.
+- CLI, MCP, TUI, and future local-server/web surfaces are adapters.
+- renderers are output formats only.
+- CorpusStore is truth.
+- SourceSpan is mandatory.
+- vector search is recall, not authority.
+- graph reads are closed-world by default.
+- LegalDomainProvider and GraphProvider are separate.
+- Isaacus alignment is strategic but provider-pluggable.
+- DuckDB + DuckPGQ is the leading local graph-query candidate, subject to verification.
+- Graphiti and FalkorDB remain provider candidates, not architecture.
+- agentic TUI is command-governed and authority-aware.
+- Evidence Packs prove process and sources, not legal correctness.

--- a/docs/superpowers/specs/2026-06-16-cli-tui-legal-workbench-design.md
+++ b/docs/superpowers/specs/2026-06-16-cli-tui-legal-workbench-design.md
@@ -1,7 +1,7 @@
 # jurisd CLI/TUI legal reasoning workbench design
 
 Date: 2026-06-16
-Status: approved design, pending implementation plan
+Status: approved design, remediated after adversarial review, pending implementation plan
 Scope: jurisd CLI, TUI, MCP adapter foundations, command contracts, help, completions, security conventions, and north-star architecture for local corpora, vector recall, graph traversal, provider enrichment, and source-backed legal reasoning.
 
 ## 1. Product stance
@@ -25,6 +25,8 @@ Core invariant:
 > No source span, no trusted legal claim.
 
 Vector search is recall, not legal authority. Graph traversal is a map over stored relationships, not a proof of law. External enrichment is candidate generation unless accepted through deterministic gates or review.
+
+Offline operation is a first-class requirement for local corpora. Local search, source-span inspection, accepted graph traversal, provenance tracing, and review of already-imported material must work without network access. Provider-backed enrichment, external fetches, remote embeddings, and credentialed services are optional capabilities. When unavailable, commands return typed `capability_missing` or `provider_unavailable` results rather than silently degrading into weaker claims.
 
 ## 2. WorkingMem terminology alignment
 
@@ -98,24 +100,19 @@ MCP names remain stable `snake_case`. CLI names use task-oriented command words.
 
 ### 3.1 Command contract fields
 
-Every public command contract must declare:
+Every public command contract must declare required, defaulted, and adapter-conditional metadata.
+
+Required for every public command:
 
 - stable command id
-- aliases
 - synopsis
 - summary
-- description
 - arguments
 - flags
 - stdin mode
 - output modes
-- examples
 - exit codes
 - validation schema
-- completion provider metadata
-- MCP mapping, if exposed
-- TUI metadata, if exposed
-- docs anchor
 - stability level
 - side-effect class
 - dangerousness
@@ -125,7 +122,16 @@ Every public command contract must declare:
 - capability gates
 - result contract
 
-Missing required metadata fails tests.
+Adapter-conditional metadata is required only where the adapter is enabled:
+
+- aliases
+- completion provider metadata
+- MCP mapping, if exposed
+- TUI metadata, if exposed
+- docs anchor
+- examples
+
+Defaultable fields must still resolve to explicit values in the generated contract. Missing required metadata fails tests. Missing adapter-conditional metadata fails tests only when that adapter is enabled for the command.
 
 ### 3.2 Adapter eligibility metadata
 
@@ -161,6 +167,8 @@ MCP tools are limited to stable, frequent, externally useful query and review in
 Operator, install, update, fetch, destructive, filesystem-write, and network-write commands are CLI-only unless a later decision explicitly allows them under an authority contract.
 
 Existing MCP tool names and schemas must remain compatible unless explicitly documented as a breaking change. Current 15 MCP tools stay stable during the first CLI/TUI foundation PR.
+
+The compatibility set must be enumerated in a generated or committed MCP compatibility reference before implementation starts. The reference must list each existing tool name, schema version or schema hash, result contract, and compatibility test. The spec does not rely on memory of the current 15 tools.
 
 Safe future MCP workbench tools may include:
 
@@ -349,6 +357,30 @@ The agent may plan and run governed commands:
 
 The agent is not a separate backend. It operates through the command contract registry and authority-aware execution service.
 
+#### 6.1.1 Agent architecture boundary
+
+The agentic TUI is implemented as an orchestration layer over command contracts, not as an unrestricted tool runner.
+
+Minimum components:
+
+- `AgentPlanner`, converts user intent into a typed plan made only of known command ids and typed arguments.
+- `AgentContextAssembler`, selects source spans, prior command results, corpus scope, graph paths, and review state for planner context.
+- `AgentExecutor`, dispatches approved plan steps through the authority-aware execution service.
+- `AgentStateStore`, records plans, step state, interruptions, partial results, and resumability metadata.
+- `AgentProvider`, supplies model-backed or rule-backed planning. Provider output is untrusted until validated against the command contract registry.
+
+Agent plans are typed data, not prose. A plan step cannot execute unless its command id exists, its arguments validate, its adapter is permitted, and its side-effect class passes authority checks.
+
+The first foundation PR must not implement a full natural-language planner. It may include only the UI and contract seams needed for a later planner.
+
+#### 6.1.2 Agent failure and interruption rules
+
+If a plan step fails, the agent must classify the failure as validation error, no results, source unavailable, capability missing, auth failure, network failure, unsafe operation refused, or internal error.
+
+The agent may continue only where the plan declares the failed step as optional. Otherwise it must stop, show partial results, and ask for user direction.
+
+Interrupting a running plan cancels pending steps, requests cancellation of active steps where supported, preserves completed result blocks, and records an audit or transcript event.
+
 Read-only operations may run automatically within the active corpus scope:
 
 - local search
@@ -376,7 +408,11 @@ Agent plans must be visible. Running plans must be interruptible. Every agent ac
 
 ### 6.2 TUI terminal behaviour
 
-Default TUI preserves native terminal scrollback. It does not use alternate screen by default. Completed output is stable, selectable, and copy-friendly.
+The TUI has two display modes.
+
+Default inline mode preserves native terminal scrollback. Completed output is stable, selectable, and copy-friendly.
+
+Future full-workbench mode may use alternate screen for multi-pane interaction, provided it can export or print a stable transcript of completed commands and reasoning traces. The first TUI foundation must not assume that all interfaces require alternate screen.
 
 The TUI must honour:
 
@@ -443,6 +479,53 @@ A source span connects:
 
 Every legal assertion is either traceable to source spans or explicitly marked as proposed, unresolved, inferred, degraded, or rejected.
 
+#### 7.1.1 Minimum SourceSpan schema
+
+A `SourceSpan` is immutable and belongs to one document version.
+
+Minimum fields:
+
+```ts
+type SourceSpan = {
+  span_id: string;
+  corpus_id: string;
+  source_document_id: string;
+  document_version_id: string;
+  source_blob_id?: string;
+  span_type:
+    | "document"
+    | "page"
+    | "paragraph"
+    | "heading"
+    | "provision"
+    | "schedule"
+    | "clause"
+    | "citation"
+    | "pinpoint"
+    | "selection"
+    | "generated_reference";
+  locator_type: "char_range" | "page" | "paragraph" | "provision" | "xpath" | "external";
+  locator_value: string;
+  char_start?: number;
+  char_end?: number;
+  page_start?: number;
+  page_end?: number;
+  parent_span_id?: string;
+  content_hash?: string;
+  created_at: string;
+  supersedes_span_id?: string;
+};
+```
+
+Rules:
+
+- spans may overlap
+- nested spans use `parent_span_id`
+- document changes create a new `document_version_id` and new spans
+- old spans are preserved and may be marked superseded through review or provenance metadata
+- cross-document relationships are graph edges or relationship claims, not single spans
+- inferred relationship claims may reference multiple source spans and must be marked `inferred`, `proposed`, or `needs_review` unless accepted by deterministic gates or review
+
 ### 7.2 Canonical local data model
 
 Minimum north-star concepts:
@@ -478,7 +561,7 @@ The first CLI/TUI foundation PR does not need to implement this model. It must a
 Preferred local direction, subject to spikes:
 
 - DuckDB as local analytical substrate where stable and packageable
-- DuckPGQ as preferred local graph-query candidate, subject to maturity and packaging verification
+- DuckDB plus a verified graph-query extension or graph-over-table approach as a primary spike candidate, subject to maturity, packaging, TypeScript integration, persistence, offline extension loading, and licence verification
 - SQLite adjacency tables as safe fallback baseline
 - sqlite-vec, DuckDB vector extension, or local pgvector profile for vector recall, selected by verification
 
@@ -516,8 +599,9 @@ Required operations:
 
 Potential backends:
 
-- DuckDB plus DuckPGQ
-- LadybugDB
+- DuckDB plus a verified graph-query extension or graph-over-table approach
+- Kuzu, only if maintenance status and packaging are acceptable
+- LadybugDB, only after project identity and maturity are verified
 - SQLite adjacency tables
 - PostgreSQL adjacency tables
 - FalkorDB
@@ -526,7 +610,26 @@ Potential backends:
 - RDF/SPARQL backend
 - production custom backend
 
-DuckDB plus DuckPGQ is the leading local graph-query candidate because it aligns with embedded analytics, Parquet data modules, graph-over-table querying, and export workflows. LadybugDB is a candidate embedded property-graph backend and likely Kuzu successor, subject to verification. Graphiti is a candidate temporal graph-memory provider, not the architecture.
+DuckDB plus a verified graph-query extension or graph-over-table approach is a primary spike candidate because it may align with embedded analytics, Parquet data modules, graph-over-table querying, and export workflows. It is not selected until packaging, TypeScript integration, persistence, offline extension loading, and licence are verified.
+
+Kuzu, SQLite adjacency tables, PostgreSQL adjacency tables, FalkorDB, RDF/SPARQL backends, and other embedded or service-backed graph systems remain candidates behind `GraphProvider`.
+
+LadybugDB must not be treated as a candidate until its project identity, repository, licence, maintenance status, persistence model, and TypeScript integration are verified.
+
+Graphiti is a candidate temporal graph-memory backend behind `GraphProvider`, not the architecture and not a substitute for the CorpusStore.
+
+GraphProvider backend selection criteria must include:
+
+- source-span preservation
+- review-state filtering
+- closed-world scope filtering
+- temporal filtering, where claimed
+- efficient predicate pushdown for corpus, matter, compartment, review state, edge type, and time slice
+- local/offline operation, where required
+- TypeScript integration
+- packaging and installation complexity
+- persistence and backup model
+- licence and project maturity
 
 ### 7.5 Graph query language
 
@@ -549,13 +652,13 @@ jurisd graph subgraph <node>
 jurisd graph as-of <date>
 ```
 
-Native expert mode:
+Native expert mode is backend-dependent:
 
 ```text
-jurisd graph query --language pgq '...'
-jurisd graph query --language cypher '...'
-jurisd graph query --language sparql '...'
+jurisd graph query --language <backend-supported-language> '...'
 ```
+
+Examples may include `pgq`, `cypher`, or `sparql` only when the configured backend supports that language. Native query support is not a promise that all graph backends or all languages are available.
 
 Native query remains policy-wrapped. It must not bypass corpus scope, review-state policy, closed-world mode, time slicing, source-span requirements, or audit controls.
 
@@ -808,6 +911,38 @@ MVP may begin with:
 - superseded
 - unresolved
 
+### 11.1 MVP review state transitions
+
+MVP valid transitions:
+
+| From       | To         | Notes                                                               |
+| ---------- | ---------- | ------------------------------------------------------------------- |
+| proposed   | accepted   | reviewer accepts the claim or relationship for current corpus scope |
+| proposed   | rejected   | reviewer rejects the claim or relationship                          |
+| proposed   | disputed   | reviewer records conflict or unresolved disagreement                |
+| proposed   | unresolved | reviewer cannot resolve with current sources                        |
+| accepted   | disputed   | later evidence or reviewer challenge                                |
+| accepted   | superseded | newer source, correction, or replacement                            |
+| rejected   | disputed   | reviewer challenge or new evidence                                  |
+| rejected   | superseded | replaced by corrected extraction or relationship                    |
+| disputed   | accepted   | dispute resolved in favour                                          |
+| disputed   | rejected   | dispute resolved against                                            |
+| disputed   | unresolved | insufficient source material                                        |
+| unresolved | proposed   | new extraction, source, or provider result reopens item             |
+| unresolved | rejected   | enough evidence to reject                                           |
+| superseded | proposed   | only by creating a new review item or corrected successor           |
+
+Every transition records:
+
+- review item id
+- from state
+- to state
+- actor or system actor
+- reason, where supplied
+- timestamp
+- source spans or result ids considered
+- audit or provenance event id
+
 Confidence/corroboration terms:
 
 - confidence_label
@@ -886,6 +1021,8 @@ JADE session cookies, Isaacus keys, provider keys, and graph backend credentials
 
 Evidence Packs are externally verifiable export bundles with proof material. Ordinary CLI/TUI/MCP responses are typed result blocks with provenance metadata, not Evidence Packs.
 
+Every command returns typed result blocks unless it explicitly invokes export behaviour. Evidence Packs are created only by explicit export commands, for example `jurisd export evidence-pack`, or by a clearly named future flag. Ordinary search, graph, review, and MCP responses are not Evidence Packs.
+
 An Evidence Pack contains:
 
 - source spans
@@ -897,6 +1034,21 @@ An Evidence Pack contains:
 - provider and model versions
 - degradation notes
 - command and audit events
+
+The expected Evidence Pack shape is a directory or zip bundle containing at minimum:
+
+```text
+manifest.json
+sources/
+spans/
+graph/
+review/
+provenance/
+audit/
+README.md
+```
+
+`manifest.json` records bundle schema version, source hashes, included commands, provider versions, degradation notes, and verification metadata. Full schema is deferred to the Evidence Pack stage.
 
 An Evidence Pack proves what the system used, which sources were present, which policy and review state existed, and how an output was produced. It does not prove that a legal conclusion is correct.
 
@@ -968,80 +1120,108 @@ Generated sections must have deterministic ordering and visible generated notice
 - changelog fragment rules
 - PR checklist
 
-## 16. First PR scope
+## 16. Foundation PR staging
 
-The first PR ships foundations only.
+The foundation work is split into reviewable PRs. Each PR must be independently mergeable and must not claim to ship later-stage corpus, graph, vector, provider, or agentic capabilities.
+
+### 16.1 Foundation PR 1: command contracts, CLI skeleton, and MCP compatibility
 
 Deliver:
 
-1. Repo conventions: `AGENTS.md`, strengthened `CONTRIBUTING.md`, rules for command contracts, generated docs, tests, security, and anti-slop examples.
-2. Command contract architecture: command contract registry with authority metadata, adapter metadata, side-effect classification, capability gates, result contract hooks, registry coverage tests.
-3. MCP compatibility preservation: existing 15 MCP tools remain stable, MCP names stay `snake_case`, no operator/admin commands exposed over MCP by default, compatibility tests prove behaviour is not broken.
-4. CLI foundation: grouped command UX, compatibility aliases for existing flat commands, per-command help, global help topics, stable exit codes, stdout/stderr rules, `--json`, `--plain`, `--no-color`, `--debug`, actionable errors.
-5. Shell completions: bash, zsh, fish, and PowerShell if practical, generated from metadata with shell-safe escaping tests.
-6. TUI foundation: `jurisd tui`, command palette, transcript/composer layout, slash commands, minimal natural-language planning boundary, and future pane placeholders.
-7. Docs: authored CLI guide, authored TUI guide, generated command reference, completion install docs, security and authority docs, architecture/north-star section.
-8. Security review artefact: committed checklist/report covering terminal injection, no-shell invariant, completion injection, credential redaction, MCP exposure, and authority boundaries.
+1. Repo conventions: `AGENTS.md`, strengthened `CONTRIBUTING.md`, generated-file rules, required tests, security constraints, docs rules, review standards, anti-slop rules, and how to add a command once.
+2. Command contract architecture: command contract registry with authority metadata, adapter metadata, side-effect classification, capability gates, result contract hooks, and registry coverage tests.
+3. MCP compatibility preservation: existing MCP tools remain stable, MCP names stay `snake_case`, no operator/admin commands exposed over MCP by default, and compatibility tests prove behaviour is not broken.
+4. CLI foundation: grouped command UX skeleton, compatibility aliases for existing flat commands, per-command help shape, global help topics, stable exit codes, stdout/stderr rules, `--json`, `--plain`, `--no-color`, `--debug`, and actionable error shape.
+5. Docs skeleton: authored CLI guide outline, generated command reference pipeline, and security/authority documentation outline.
+6. Security checklist: committed checklist covering terminal injection, no-shell invariant, credential redaction, MCP exposure, and authority boundaries.
 
-Explicitly do not build in the first PR:
+Explicitly do not build in PR 1:
 
 - full CorpusStore
-- DuckDB/DuckPGQ integration
-- LadybugDB integration
-- Graphiti integration
-- vector indexing
 - source import pipeline
+- vector indexing
+- graph backend integration
+- shell completion generation beyond command metadata seams
+- full TUI
+- natural-language planner
 - Evidence Pack export
 - Isaacus provider integration
-- full agentic planner
-- graph visualisation
-- review queue persistence
 
-The first PR must make room for those features without pretending to ship them.
+### 16.2 Foundation PR 2: completions, generated docs, and security hardening
 
-## 17. Staging after the first PR
+Deliver:
+
+1. bash, zsh, fish completions, and PowerShell if practical, generated from metadata
+2. shell-safe escaping tests
+3. generated command reference
+4. completion install docs
+5. stale generated-doc and completion checks
+6. expanded security review artefact
+
+### 16.3 Foundation PR 3: TUI scaffold
+
+Deliver:
+
+1. `jurisd tui` entry point
+2. selected terminal framework
+3. command palette over command contracts
+4. transcript/composer layout
+5. slash-command dispatch to governed command contracts
+6. future pane placeholders
+7. no full natural-language planner
+
+### 16.4 Later PR: agentic TUI
+
+The agentic TUI planner is implemented only after the planner architecture, command constraints, context assembly, failure handling, provider boundaries, and audit model are designed and tested.
+
+## 17. Staging after foundation PRs
 
 Recommended stages:
 
 1. Source custody and CorpusStore.
 2. Parser/source spans and document-interior extraction.
 3. Lexical and semantic recall.
-4. GraphProvider with DuckDB/DuckPGQ or adjacency backend spike.
+4. GraphProvider with DuckDB-backed graph-over-table or adjacency backend spike.
 5. Review workflow.
-6. Agentic TUI workbench.
-7. Evidence Pack export.
-8. MCP workbench tools.
-9. Isaacus and self-hosted provider adapters.
-10. Advanced graph and vector backends.
+6. TUI scaffold and command-palette workbench.
+7. Agentic TUI planner and governed research workflows.
+8. Evidence Pack export.
+9. MCP workbench tools.
+10. Isaacus and self-hosted provider adapters.
+11. Advanced graph and vector backends.
 
-## 18. Acceptance criteria for the first PR
+## 18. Acceptance criteria for Foundation PR 1
 
-The first PR is acceptable only if:
+Foundation PR 1 is acceptable only if:
 
-- command metadata is not duplicated by hand across MCP, CLI, TUI, docs, and completions
+- command metadata is not duplicated by hand across MCP, CLI, docs, and future adapter seams
 - adding a command without required metadata fails tests
 - existing MCP tool names and schemas remain compatible
-- CLI help is useful, not schema-dump prose
+- the current MCP compatibility set is enumerated in a committed or generated reference
+- CLI help shape is useful, not schema-dump prose
 - CLI errors are actionable
 - stdout/stderr behaviour is documented and tested
-- completions are deterministic and shell-safe
-- TUI starts and exposes command palette/help
 - docs explain the north-star architecture without claiming v1 has all of it
-- security review is committed
+- security checklist is committed
 - full test, lint, and build pass
 
 ## 19. Open verification items
 
 Before implementation of later graph/vector/provider stages, verify with current external research:
 
-- DuckDB + DuckPGQ packaging, TypeScript integration, maturity, persistence, and offline extension story
-- LadybugDB packaging, licence, persistence, TypeScript integration, and project maturity
+- DuckDB graph-query options, including whether DuckPGQ or any similarly named project is a DuckDB extension, PostgreSQL extension, standalone project, or unsuitable; verify packaging, TypeScript integration, maturity, persistence, offline extension loading, and licence
+- Kuzu, SQLite adjacency tables, PostgreSQL adjacency tables, FalkorDB, RDF/SPARQL backends, and any proposed LadybugDB candidate; verify project identity, licence, persistence, TypeScript integration, local/offline operation, and project maturity
 - Graphiti backend support, temporal semantics, provenance model, licensing, and operational maturity
 - sqlite-vec, DuckDB vector extensions, pgvector, pgvectorscale, VectorChord, LanceDB, Qdrant, and Weaviate trade-offs
 - Isaacus/Kanon Embedder, Reranker, Enricher, ILDGS, Blackstone Graph schema, access, licence, and Australian coverage
 - Docling, OCR, paragraph-preserving legal parsers, LegalDocML/Akoma Ntoso, and citation resolvers
 - terminal framework suitability for the TUI workbench model
 - MCP patterns for scoped, provenance-bearing, capability-aware tools
+- SourceSpan schema against nested provisions, overlapping spans, paragraph and page locators, scanned PDFs, external citations, and inferred multi-source relationships
+- review state machine with legal research workflows and correction/dispute paths
+- PDF parsing and OCR pipelines against representative Australian legal PDFs, including degraded fallback for unparseable documents
+- terminal framework suitability before TUI scaffold implementation, including inline mode, alternate-screen mode, keyboard navigation, accessibility, and transcript export
+- agent planner architecture, including model/provider boundary, command registry constraints, context assembly, failure handling, interruption, cost controls, and auditability
 
 ## 20. Design decisions summary
 
@@ -1055,7 +1235,7 @@ Before implementation of later graph/vector/provider stages, verify with current
 - graph reads are closed-world by default.
 - LegalDomainProvider and GraphProvider are separate.
 - Isaacus alignment is strategic but provider-pluggable.
-- DuckDB + DuckPGQ is the leading local graph-query candidate, subject to verification.
-- Graphiti and FalkorDB remain provider candidates, not architecture.
+- DuckDB-backed graph-over-table or graph-extension approaches are primary spike candidates, subject to verification.
+- Graphiti, FalkorDB, Kuzu, RDF/SPARQL backends, and other graph systems remain backend candidates behind `GraphProvider`, not the architecture itself.
 - agentic TUI is command-governed and authority-aware.
 - Evidence Packs prove process and sources, not legal correctness.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -101,7 +101,7 @@ All configuration is managed through the ConfigMap (`k8s/configmap.yaml`). To mo
 | `AUSTLII_USER_AGENT`    | Mozilla/5.0...                                    | User agent string            |
 | `AUSTLII_TIMEOUT`       | `60000`                                           | Request timeout (ms)         |
 | `JADE_BASE_URL`         | `https://jade.io`                                 | jade.io base URL             |
-| `JADE_USER_AGENT`       | `jurisd/0.1.0 (legal research tool)`              | jade.io user agent           |
+| `JADE_USER_AGENT`       | `jurisd/0.2.0 (legal research tool)`              | jade.io user agent           |
 | `JADE_TIMEOUT`          | `15000`                                           | jade.io request timeout (ms) |
 | `DEFAULT_SEARCH_LIMIT`  | `10`                                              | Default search results       |
 | `MAX_SEARCH_LIMIT`      | `50`                                              | Maximum search results       |

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -36,7 +36,7 @@ data:
     # jurisd Configuration
     server:
       name: jurisd
-      version: 0.1.0
+      version: 0.2.0
       description: Australian legislation and case law searcher with document retrieval.
 
     austlii:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2958,9 +2958,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4221,16 +4221,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4476,9 +4476,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4915,10 +4915,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5245,10 +5255,20 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -5510,15 +5530,25 @@
       "license": "ISC"
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "jurisd",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jurisd",
-      "version": "0.1.0",
-      "license": "MIT",
+      "version": "0.2.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@duckdb/node-api": "^1.5.3-r.3",
         "@huggingface/transformers": "^3.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jurisd",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Model Context Protocol server for Australian legislation and case law search.",
   "main": "dist/index.js",
   "bin": {
@@ -21,8 +21,8 @@
     "test:coverage": "vitest run --coverage",
     "test:smoke": "vitest run src/test/smoke/",
     "test:watch": "vitest watch",
-    "lint": "eslint src --ext .ts",
-    "lint:fix": "eslint src --ext .ts --fix",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "docs": "typedoc",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,15 +1,6 @@
 {
-  "entryPoints": [
-    "src/index.ts",
-    "src/services/austlii.ts",
-    "src/services/fetcher.ts",
-    "src/services/jade.ts",
-    "src/utils/formatter.ts",
-    "src/utils/logger.ts",
-    "src/config.ts",
-    "src/constants.ts",
-    "src/errors.ts"
-  ],
+  "entryPoints": ["src"],
+  "entryPointStrategy": "expand",
   "out": "docs/api",
   "exclude": ["**/*.test.ts", "src/test/**", "node_modules"],
   "excludePrivate": true,


### PR DESCRIPTION
## Summary
- bump jurisd package/config/docs metadata to 0.2.0 and cut the changelog release section
- sync Docker, k8s, TypeDoc, licence and Node 26 documentation
- update Docker workflow to build PRs, publish on main/tag/manual runs, and emit semver image tags for releases

## Verification
- rtk proxy npm run build
- rtk proxy npm run lint (passes with existing no-console warnings in src/test/citator.test.ts)
- rtk proxy npm run format:check
- rtk proxy npm run docs (passes with existing TypeDoc warnings)
- CI=true rtk proxy npm test
- CI=true rtk proxy npm run test:smoke
- rtk proxy git diff --check

## Notes
- Local non-CI npm test and smoke tests still hit AustLII live endpoints and fail under Cloudflare challenge without AUSTLII_CF_CLEARANCE, as designed.
- Local container build/push was not run because the Claude Code Bash safety classifier blocked podman/docker execution in this session. The Docker workflow now validates PR builds and publishes images on main/tag/manual workflow runs.