### PR TITLE
docs: Consolidate roadmap documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ at `fetch-module` install time.
 | [AGENT-GUIDE.md](docs/AGENT-GUIDE.md)                    | Agent-facing usage guide with full tool catalog and examples               |
 | [ARCHITECTURE.md](docs/ARCHITECTURE.md)                  | System architecture, deployment topology, CI/CD                            |
 | [DOCKER.md](docs/DOCKER.md)                              | Docker deployment guide                                                    |
-| [ROADMAP.md](docs/ROADMAP.md)                            | Development history and future plans                                       |
+| [ROADMAP.md](docs/ROADMAP.md)                            | Forward-looking project roadmap and review gates                           |
 
 ## Jurisdictions
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,354 +1,100 @@
-# Feature Development Roadmap
+# Roadmap
 
-## Current State Analysis
+This roadmap tracks forward work only. Delivered architecture and command
+surface details live in the focused reference docs:
 
-### What Works Well ✅
+- [Architecture](ARCHITECTURE.md)
+- [Install guide](INSTALL.md)
+- [CLI guide](CLI.md)
+- [MCP compatibility](MCP-COMPATIBILITY.md)
+- [Security and authority model](SECURITY-AUTHORITY.md)
+- [Agent guide](AGENT-GUIDE.md)
 
-- Fetches recent case law from AustLII
-- Filters out journal articles (primary sources only)
-- Extracts neutral citations and jurisdictions
-- Preserves paragraph numbers in `[N]` format (402 instances found in test)
-- Handles HTML and PDF documents
+## Current Product State
 
-### Current Limitations 🔴
+jurisd is a pre-1.0 Australian and New Zealand legal research tool with:
 
-#### 1. **Search Quality Issues**
+- MCP tools for live AustLII search, source fetching, citation formatting, and bibliography work.
+- Optional jade.io citation enhancement when the operator supplies their own session cookie.
+- Local data-module plumbing for deterministic provision lookup, local semantic recall, and citation graph traversal.
+- CLI parity for the current MCP tool surface.
+- Day-0 packaging, Docker, and install documentation.
 
-- **Problem**: Searching "Donoghue v Stevenson" returns recent 2025 cases that merely cite it, NOT the actual 1932 case
-- **Root cause**: Sorting by date prioritises recent cases over relevance
-- **Impact**: Users can't find the specific case they're looking for
+The main product gap is not another historical implementation phase. It is
+turning the existing engine into a governed workbench with reviewable source
+custody, offline data modules, and operator-safe workflows.
 
-#### 2. **Limited Sources**
+## Workstreams
 
-- **Current**: Only searches AustLII
-- **Missing**: jade.io (superior reported judgments), BarNet Jade, other authoritative sources
-- **Impact**: May miss best/most authoritative version of judgments
+### 1. First Public Data Module
 
-#### 3. **Paragraph Number Preservation**
+Deliver the first redistributable data module and make module install behaviour
+observable end to end.
 
-- **Current**: Text extraction strips HTML structure
-- **Found**: `[N]` format markers ARE preserved (402 instances)
-- **Issue**: Page numbers from reported judgments are lost
-- **Impact**: Can't generate accurate pinpoints for reported citations
+- Publish the first public baseline module.
+- Verify manifest validation, file hash checks, and atomic install from a clean clone.
+- Keep non-redistributable sources recipe-only.
+- Document exact operator commands once a module is available.
 
-#### 4. **No Ranking/Relevance**
+Review artefact: fresh-clone module install, verify, list, and one local recall
+query against the published module.
 
-- **Problem**: No way to prioritise authoritative sources
-- **Missing**: Reported vs unreported distinction, court hierarchy weighting
+### 2. CLI/TUI Reasoning Workbench
 
-## Proposed Solutions
+Build the research workbench on top of the governed command contracts.
 
-### Phase 1: Fix Search Relevance (HIGH PRIORITY)
+- Keep command contracts as the single source for CLI help, generated references, and shell completions.
+- Add the TUI scaffold without weakening MCP compatibility.
+- Introduce authority-aware execution and typed result blocks.
+- Add source custody, fixture corpus import, lexical recall, semantic recall, and graph traversal over a closed corpus.
+- Add review workflow, evidence pack export, and curated MCP workbench tools.
 
-**Goal**: Return the ACTUAL case being searched for, not just cases that cite it
+Review artefact: a functional CLI/TUI workflow that imports a fixture source,
+runs recall, shows source-backed results, and exports a reviewable evidence pack.
 
-**Implementation**:
+### 3. Public Documentation Hygiene
 
-1. **Add search mode parameter**: `relevance` vs `date` sorting
-2. **Smart query detection**:
-   - If query looks like case name (e.g. "X v Y"), use relevance
-   - If query is topic (e.g. "negligence"), use date for recency
-3. **Title matching boost**: Prioritise exact title matches
-4. **Citation matching**: Parse citations from query and match
+Keep public documentation product-facing and safe.
 
-**Code changes**:
+- Remove internal planning artefacts, stale build logs, and private local conventions.
+- Keep contact and security reporting metadata consistent.
+- Consolidate overlapping docs into a small set of maintained guides.
+- Avoid publishing workflow codenames as user-facing structure.
 
-```typescript
-interface SearchOptions {
-  jurisdiction?: "cth" | "vic" | "federal" | "other";
-  limit?: number;
-  type: "case" | "legislation";
-  sortBy?: "relevance" | "date" | "auto"; // NEW
-}
-```
+Review artefact: docs-only PR with link checks, stale-reference checks, and a
+clear before/after navigation surface.
 
-### Phase 2: Multi-Source Integration (MEDIUM PRIORITY)
+### 4. In-Workflow Module Management
 
-**Goal**: Search multiple authoritative sources and return best results
+Expose module lifecycle information safely inside the research workflow.
 
-**Sources to integrate**:
+- Surface installed, refused, and available module versions.
+- Add approval-gated module fetch/update flows.
+- Preserve CLI parity for every in-workflow module operation.
+- Keep large downloads and filesystem writes out of unapproved assistant paths.
 
-1. **jade.io** - Superior reported judgments with page numbers
-2. **BarNet Jade** - Free access to some reported cases
-3. **AustLII** - Comprehensive unreported coverage (current)
+Review artefact: approval-gated workflow that lists available modules and
+requires explicit confirmation before install or update.
 
-**Implementation approach**:
+### 5. Corpus Coverage Expansion
 
-```typescript
-// Parallel search across sources
-const [austliiResults, jadeResults] = await Promise.all([
-  searchAustLii(query, options),
-  searchJade(query, options), // NEW
-]);
+Expand coverage without weakening licensing and provenance controls.
 
-// Merge and deduplicate by citation
-const merged = deduplicateResults([...austliiResults, ...jadeResults]);
+- Add redistributable state and territory sources where licensing permits.
+- Keep restricted sources recipe-only.
+- Preserve per-source licence verdicts in module metadata.
+- Add source-specific fixtures before promoting a source into a public module.
 
-// Rank by authority: Reported > Unreported, Higher court > Lower court
-const ranked = rankByAuthority(merged);
-```
+Review artefact: one new source pipeline with licence verdict, fixtures, module
+metadata, and local recall validation.
 
-**Challenges**:
+## Gates
 
-- jade.io may require authentication/API key
-- Need to handle different HTML structures per source
-- Deduplication logic must match same case across sources
+Every roadmap PR must produce a reviewable artefact, not only isolated unit
+tests. A PR is ready for human review when:
 
-### Phase 3: Enhanced Paragraph/Page Preservation (HIGH PRIORITY)
-
-**Goal**: Preserve both paragraph numbers AND page numbers for accurate pinpoint citations
-
-**Current state**:
-
-- `[N]` paragraph markers: ✅ Preserved (402 found)
-- Page numbers: ❌ Lost in text extraction
-
-**Implementation**:
-
-1. **Improve HTML parsing** to preserve structural markers:
-
-   ```typescript
-   // Keep paragraph markers
-   <p class="Judg-Para-1">[1]</p> → "[1]"
-
-   // Extract page markers (when present in reported versions)
-   <span class="page-num">123</span> → "[Page 123]"
-   ```
-
-2. **Return structured content**:
-
-   ```typescript
-   interface EnhancedFetchResponse extends FetchResponse {
-     paragraphs?: Array<{
-       number: number;
-       text: string;
-       pageNumber?: number;
-     }>;
-   }
-   ```
-
-3. **Pinpoint generation helper**:
-   ```typescript
-   function generatePinpoint(
-     text: string,
-     searchPhrase: string,
-   ): { paragraph?: number; page?: number } {
-     // Find paragraph/page containing phrase
-   }
-   ```
-
-### Phase 4: Intelligent Result Ranking (MEDIUM PRIORITY)
-
-**Goal**: Return best/most authoritative version of each case
-
-**Ranking criteria** (in order):
-
-1. **Reported vs unreported**: Reported judgments rank higher
-2. **Court hierarchy**: HCA > Full Court > Single judge
-3. **Completeness**: Judgments with page numbers > without
-4. **Recency**: For topic searches, prefer recent
-5. **Relevance**: Title/citation exact match > partial match
-
-**Implementation**:
-
-```typescript
-function calculateAuthorityScore(result: SearchResult): number {
-  let score = 0;
-
-  // Reported judgment
-  if (result.citation && !result.neutralCitation) score += 100;
-
-  // Court hierarchy
-  if (result.url.includes("/HCA/")) score += 50;
-  else if (result.url.includes("/FCA/")) score += 30;
-  // ... etc
-
-  // Has page numbers
-  if (result.metadata?.hasPageNumbers) score += 20;
-
-  return score;
-}
-```
-
-## Implementation Status
-
-### ✅ Phase 1: Search Relevance (COMPLETED)
-
-**Implemented features:**
-
-1. ✅ Smart query detection: Auto-detects case names ("X v Y", "Re X", citations) vs topic searches
-2. ✅ `sortBy` parameter: "auto" (default), "relevance", or "date" modes
-3. ✅ Title matching boost: Prioritizes exact case name matches in results
-4. ✅ Auto mode intelligence:
-   - Case name queries → relevance sorting to find specific cases
-   - Topic queries → date sorting for recent jurisprudence
-5. ✅ Comprehensive test suite: 7 new tests covering all sorting scenarios
-
-**What was fixed:**
-
-- ❌ **OLD**: Searching "Donoghue v Stevenson" returned 2025 cases citing it
-- ✅ **NEW**: Search returns the actual case being searched for
-
-**Technical details:**
-
-- Pattern detection for "X v Y", "Re X", citations, and quoted queries
-- Title scoring algorithm with party name matching
-- Configurable sorting with sensible defaults
-
-## Implementation Priority
-
-### Must Have (Next Sprint)
-
-1. ✅ ~~Fix search relevance for case name queries~~ (COMPLETED)
-2. ✅ ~~Preserve paragraph numbers properly~~ (already working)
-3. ✅ ~~Add search mode parameter (relevance/date/auto)~~ (COMPLETED)
-
-### ✅ Phase 2A: Reported Citations & jade.io Support (COMPLETED)
-
-**Implemented features:**
-
-1. ✅ Reported citation extraction from AustLII results
-   - Extracts citations like `(2024) 350 ALR 123`, `(1992) 175 CLR 1`
-   - Supports common law report patterns (CLR, ALR, ALJR, etc.)
-   - Automatically extracted from titles and summaries
-2. ✅ jade.io URL support in document fetcher
-   - Users can paste jade.io URLs they have access to
-   - Special HTML parsing for jade.io document structure
-   - Falls back to generic extraction when needed
-3. ✅ Enhanced SearchResult interface
-   - Added `reportedCitation` field
-   - Updated `source` to support both "austlii" and "jade"
-4. ✅ New test coverage (4 additional tests)
-
-**What this enables:**
-
-- Users can now see both neutral and reported citations
-- More complete citation information for legal research
-- jade.io integration without needing API access
-- Users leverage their own jade.io subscriptions
-
-**Technical implementation:**
-
-- `extractReportedCitation()` function with regex patterns
-- `extractTextFromJadeHtml()` for jade.io-specific parsing
-- Updated test suite with 18 total scenarios
-
-### ✅ Phase 2B: jade.io Authenticated Fetch (COMPLETED)
-
-**Implemented features:**
-
-1. ✅ `JADE_SESSION_COOKIE` environment variable for authenticated jade.io access
-2. ✅ Cookie header injection with sanitisation (printable ASCII validation, newline rejection)
-3. ✅ Helpful 401/403 error message directing user to set the env var
-4. ✅ Rate limiting: 5 req/min for jade.io, 10 req/min for AustLII (token bucket)
-
-### ✅ Phase 3: Paragraph Block Extraction and Pinpoint Citations (COMPLETED)
-
-**Implemented features:**
-
-1. ✅ `ParagraphBlock` interface with `number`, `text`, and optional `pageNumber`
-2. ✅ `paragraphs` field on `FetchResponse` - populated from `[N]` markers in AustLII HTML
-3. ✅ `generate_pinpoint` MCP tool: finds paragraph by number or phrase, returns `at [N]` string
-4. ✅ Full citation composition: `"[2022] FedCFamC2F 786 at [23]"`
-
-### ✅ Phase 4: Authority-Based Result Ranking (COMPLETED)
-
-**Implemented features:**
-
-1. ✅ `calculateAuthorityScore()` with court hierarchy scoring (HCA=100, FCAFC=80, FCA=60, state SC=30, etc.)
-2. ✅ Reported citation bonus (+10 points)
-3. ✅ Secondary sort by authority score applied to case-name queries
-
-### ✅ Phase 5: AGLC4 Citation Service (COMPLETED)
-
-**Implemented features:**
-
-1. ✅ `parseCitation()` - extracts neutral and reported citations from text
-2. ✅ `formatAGLC4()` - formats citations per AGLC4 rules
-3. ✅ `validateCitation()` - HEAD-checks citation against AustLII
-4. ✅ `generatePinpoint()` - finds paragraph by number or phrase
-5. ✅ Extended `NEUTRAL_CITATION_PATTERN` to handle mixed-case court codes (e.g. FedCFamC2F)
-6. ✅ `REPORTERS` registry and `COURT_TO_AUSTLII_PATH` map added to constants
-
-### ✅ Phase 6: Security Hardening (COMPLETED)
-
-**Implemented features:**
-
-1. ✅ `assertFetchableUrl()` - SSRF protection: HTTPS-only, allowlisted hosts (austlii.edu.au, jade.io)
-2. ✅ Cookie sanitisation: printable ASCII validation, newline injection rejection
-3. ✅ Token bucket rate limiter: 10 req/min AustLII, 5 req/min jade.io
-4. ✅ Config DRY: all hardcoded constants removed, sourced from `config.ts`
-
-### ✅ Phase 7: New MCP Tools (COMPLETED)
-
-**Four new tools registered:**
-
-1. ✅ `format_citation` - formats AGLC4 citations with neutral, reported, and pinpoint components
-2. ✅ `validate_citation` - validates neutral citations against AustLII and returns canonical URL
-3. ✅ `generate_pinpoint` - fetches a judgment and generates a pinpoint citation reference
-4. ✅ `search_by_citation` - resolves a citation to a direct URL or falls back to text search
-
-### ✅ Phase 8: jade.io Search via proposeCitables GWT-RPC (COMPLETED)
-
-**Implemented features:**
-
-1. ✅ Reverse-engineered `proposeCitables` method on `JadeRemoteService` from HAR analysis
-2. ✅ `buildProposeCitablesRequest(query)` - GWT-RPC request builder (query is the only variable)
-3. ✅ `decodeGwtInt(encoded)` - inverse of existing `encodeGwtInt` for article ID decoding
-4. ✅ `parseProposeCitablesResponse(text)` - extracts case names, neutral + reported citations, and jade article IDs from "document in Jade" descriptor anchors in the string table
-5. ✅ `searchJade(query, options)` - replaces placeholder, calls `proposeCitables` via POST to `/jadeService.do`
-6. ✅ `search_cases` MCP tool merges jade.io citation data into AustLII case-search results at runtime, deduplicating by neutral citation
-7. ✅ Graceful degradation: returns `[]` when `JADE_SESSION_COOKIE` is unset (no error to caller)
-8. ✅ HAR fixture files for deterministic testing: `propose-citables-mabo.txt` (75KB) and `propose-citables-rice.txt`
-
-**Protocol notes**:
-
-- Authentication: same `JADE_SESSION_COOKIE` as `fetch_document_text`
-- Strong name staleness: if requests return `//EX`, refresh `JADE_STRONG_NAME` from `X-GWT-Permutation` header
-- Transcripts (HCATrans) are filtered out; results without discoverable article IDs are skipped
-
-### Should Have (Future)
-
-1. 🔶 BarNet Jade integration
-2. 🔶 Related cases and legislation suggestions
-
-## 2026-04 Roadmap Audit (Feature-by-Feature)
-
-| Item                                                            | Status                             | Evidence in code/tests                                                                                                                                                                                                                               | Merge needed              |
-| --------------------------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| Phase 1: Search relevance (`auto`/`relevance`/`date`)           | ✅ Delivered                       | `src/services/austlii.ts` (`isCaseNameQuery`, `determineSortMode`, `boostTitleMatches`); tests in `src/test/unit/austlii.test.ts`, live usage in `src/test/scenarios.test.ts`                                                                        | No                        |
-| Phase 2: Multi-source search (AustLII + jade.io) + dedupe       | ✅ Delivered                       | `search_cases` tool in `src/index.ts`; `searchJade` in `src/services/jade.ts`; deterministic merge tests in `src/test/unit/search-merge.test.ts`; GWT search tests in `src/test/unit/jade-search.test.ts`                                            | No                        |
-| Phase 3: Paragraph block extraction + pinpoint                  | ✅ Delivered (paragraph pinpoints) | `ParagraphBlock` + extraction in `src/services/fetcher.ts`; pinpoint generation in `src/services/citation.ts`; tests in `src/test/unit/fetcher.test.ts`, `src/test/unit/citation.test.ts`                                                            | No                        |
-| Phase 4: Authority ranking                                      | ✅ Delivered                       | `calculateAuthorityScore` in `src/services/austlii.ts`; tests in `src/test/unit/austlii.test.ts`                                                                                                                                                     | No                        |
-| Phase 5: AGLC4 citation service                                 | ✅ Delivered                       | `src/services/citation.ts`; tests in `src/test/unit/citation.test.ts`                                                                                                                                                                                | No                        |
-| Phase 6: Security hardening (SSRF, cookie hygiene, rate limits) | ✅ Delivered                       | `src/utils/url-guard.ts`, `src/utils/rate-limiter.ts`, fetch/search sanitisation in services; tests in `src/test/unit/url-guard.test.ts`, `src/test/unit/rate-limiter.test.ts`, `src/test/unit/fetcher.test.ts`, `src/test/unit/jade-search.test.ts` | No                        |
-| Phase 7: New MCP tools                                          | ✅ Delivered                       | Tool registrations in `src/index.ts` (`format_citation`, `validate_citation`, `generate_pinpoint`, `search_by_citation`, `search_citing_cases`)                                                                                                      | No                        |
-| Phase 8: jade.io GWT-RPC search                                 | ✅ Delivered                       | `src/services/jade-gwt.ts`, `src/services/jade.ts`; tests in `src/test/unit/jade-gwt.test.ts`, `src/test/unit/jade-search.test.ts`, live-auth tests in `src/test/jade.test.ts`                                                                       | No                        |
-| BarNet Jade integration (official API/channel)                  | 🔶 RHIL blocker                    | No public/stable vendor API contract in repo; current integration uses authenticated browser-session GWT-RPC                                                                                                                                         | Yes (external dependency) |
-| Related cases suggestions                                       | ✅ Delivered (via citator)         | `search_citing_cases` tool + `searchCitingCases` service; tests in `src/test/unit/jade-citator.test.ts`, live usage in `src/test/citator.test.ts`                                                                                                    | No                        |
-
-### RHIL testability blockers and direct remedies
-
-1. **BarNet Jade official integration** (RHIL)
-   - **Why not fully testable now**: Requires vendor-side API access/contract not available in this repository.
-   - **Direct remedy**: Obtain BarNet-provided API credentials + schema + rate-limit policy, then add contract tests against a sandbox endpoint and gated CI secrets.
-
-2. **Live jade.io authenticated workflows in CI** (RHIL)
-   - **Why not fully testable now**: Requires a valid, rotating `JADE_SESSION_COOKIE`, which is intentionally unavailable in CI.
-   - **Direct remedy**: Add a scheduled/manual CI workflow with short-lived secret injection and run `src/test/jade.test.ts` + `src/test/citator.test.ts` in a dedicated authenticated test job.
-
-## Testing Requirements
-
-Each phase must include:
-
-1. **Unit tests** for new parsing/ranking logic
-2. **Integration tests** with real judgments
-3. **Comparison tests** - verify improvements over current state
-4. **Performance tests** - ensure multi-source doesn't timeout
-
-## Success Metrics
-
-1. **Search accuracy**: "Donoghue v Stevenson" returns the 1932 case, not 2025 cases
-2. **Pinpoint accuracy**: Can generate `[2025] HCA 26 at [42]` style citations
-3. **Source coverage**: Returns reported judgment when available
-4. **Response time**: < 5 seconds for multi-source search
+- The branch has a functional product check tied to the workstream.
+- Generated outputs are checked into the repo when applicable.
+- CI passes or any live-service failures are clearly isolated and explained.
+- Fresh clean-code and security reviews are complete for product-impacting changes.
+- The OpenProject work item is moved to the review gate only after the PR is functional.


### PR DESCRIPTION
## Requested

Consolidate overlapping public roadmap documentation so the repo has a forward-looking roadmap rather than a stale historical implementation log.

## Delivered

This PR replaces the long phase-by-phase `docs/ROADMAP.md` build log with a concise roadmap organised around current product gaps, workstreams, review artefacts, and PR gates. It also updates the README documentation index so the roadmap is described as a forward-looking planning document.

## Measurement

Validated the docs surface by checking Markdown formatting, confirming stale roadmap markers were removed, and verifying local Markdown links in `README.md` and `docs/ROADMAP.md` resolve. Repository checks run: `npm run build`, `npm run lint`, `npm run format:check`, and focused unit checks for config/constants.

No product runtime behaviour changed; validation is limited to docs navigation, stale-reference checks, and repository health checks.

## Review status

- Clean code review: pending
- Deep security review: pending

This PR remains draft until both fresh-context reviews are complete.
