### PR TITLE
docs: Update data module availability status

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,18 +143,18 @@ Existing flat CLI commands remain available during the foundation work.
 ## Data modules
 
 A **data module** is a self-describing parquet bundle (documents, chunks, edges,
-unmatched citations, plus a `manifest.json`) published as a GitHub release asset
-on the `jurisd-data` repository. Everything needed to load and query a module —
-schema version, coverage, embedding descriptor, file hashes, and licence posture
-— is in its manifest. No out-of-band config.
+unmatched citations, plus a `manifest.json`) published as a Hugging Face dataset.
+Everything needed to load and query a module — schema version, coverage,
+embedding descriptor, file hashes, and licence posture — is in its manifest. No
+out-of-band config.
 
-> **Status: no modules published yet.** The `jurisd-data` publishing repo and its
-> first release are still being built, so `jurisd fetch-module` has nothing to
-> download today (it resolves the release and fails fast with a `404`). The
-> server runs without any module — the live AustLII layer and citation tools work
-> standalone, and the five local-recall tools report "no modules" (degrade
-> visibly). The CLI flow below is implemented and ready for the first publish;
-> this section documents the intended install once modules land.
+> **Status: first module published.** `legislation-cth` is available from
+> `workingmem/legislation-cth` on Hugging Face. It provides Commonwealth primary
+> and secondary legislation, 32,143 documents, 857,262 chunks, citation edges,
+> unmatched citations, and local bge-small embeddings. `jurisd fetch-module
+legislation-cth` downloads the manifest and parquet files from Hugging Face,
+> verifies every file against the manifest sha256 values, and installs the module
+> atomically.
 
 Modules are queried in place: DuckDB scans the parquet on disk and never
 materialises a whole table into memory, so a host can install many modules
@@ -253,10 +253,9 @@ state, not a marketing number.
     case-law sources are redistributable under the CC-BY-4.0 aggregate, subject to
     per-source confirmation before each module publishes.
 
-The full per-source verdict table ships as `jurisd-data/LICENSING.md` with the
-first module release (the `jurisd-data` repo is still being built); each
-published module also carries its own `licence` block in `manifest.json`, surfaced
-at `fetch-module` install time.
+The full per-source verdict table lives in `jurisd-data/LICENSING.md`; each
+published module also carries its own `licence` block in `manifest.json`,
+surfaced at `fetch-module` install time.
 
 ## Documentation
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -166,14 +166,13 @@ tool surface so an AI assistant never triggers a multi-hundred-MB download
 mid-conversation. Modules are published as Hugging Face datasets under the
 `workingmem` organisation.
 
-> **Status: module publishing in progress — no modules available to fetch yet.**
-> The `workingmem` module datasets are still being built, so
-> `jurisd fetch-module` currently resolves the default manifest URL and fails
-> fast with a `404` (it never installs a partial or unverified module). This is
-> expected pre-publish. jurisd runs fully without any module: the live AustLII layer and
-> citation tools work standalone, and the five local-recall tools report "no
-> modules" (degrade visibly). The CLI flow below is implemented and ready for the
-> first publish.
+> **Status: first module published.** `legislation-cth` is available from
+> `workingmem/legislation-cth` on Hugging Face. It provides Commonwealth primary
+> and secondary legislation, 32,143 documents, 857,262 chunks, citation edges,
+> unmatched citations, and local bge-small embeddings. `jurisd fetch-module
+legislation-cth` downloads the manifest and parquet files from Hugging Face,
+> verifies every file against the manifest sha256 values, and installs the module
+> atomically.
 
 ```bash
 jurisd fetch-module <name> [--manifest-url URL] [--modules-dir DIR]


### PR DESCRIPTION
## Requested

Remove the obsolete no-modules status now that the first data module is available, and align install documentation with the actual module source.

## Delivered

This PR updates the README and install guide to state that `legislation-cth` is published from `workingmem/legislation-cth` on Hugging Face. It also corrects the module publication description from GitHub release assets to Hugging Face datasets and removes the stale pre-release licensing note.

## Measurement

Validated the live module source by resolving the Hugging Face manifest for `workingmem/legislation-cth`. The manifest reports module version `0.1.0`, schema version `1`, Commonwealth primary and secondary legislation coverage, 32,143 documents, 857,262 chunks, four parquet files, and sha256 hashes for each file.

Validated the product flow by building the CLI and running a real `jurisd fetch-module legislation-cth` install into an isolated module directory. `jurisd verify-module legislation-cth` succeeded, and `jurisd list-modules` reported one ready module with snapshot date `2026-06-13`.

Validation commands completed:

- `npm ci`
- `npm run build`
- `npm run check:generated`
- `npm run format:check && npx prettier --check README.md docs/INSTALL.md`
- `npm run lint` (0 errors, existing warnings in test code)
- `npm test -- src/test/unit/fetch-module.test.ts src/test/unit/fetch-module-verify.test.ts src/test/unit/fetch-module-security.test.ts` (28 passed)
- `npm pack --dry-run`

The full live-search test suite was not green because AustLII live search smoke, scenario, and performance tests encountered Cloudflare challenges or live fetch timeouts. Those failures are outside this docs-only change and were not bypassed with `--no-verify`.

NPM registry status was checked separately: `jurisd` and `jurisd@0.2.0` are not published. Publishing is blocked until an npm registry credential is available; local npm auth returned unauthorised and Vault did not contain `secret/npm` or an `api/` npm credential.

## Review status

- Clean code review: pending
- Deep security review: pending
