### PR TITLE
docs: Document published legislation module

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,10 @@ out-of-band config.
 > **Status: first module published.** `legislation-cth` is available from
 > `workingmem/legislation-cth` on Hugging Face. It provides Commonwealth primary
 > and secondary legislation, 32,143 documents, 857,262 chunks, citation edges,
-> unmatched citations, and local bge-small embeddings. `jurisd fetch-module
-legislation-cth` downloads the manifest and parquet files from Hugging Face,
-> verifies every file against the manifest sha256 values, and installs the module
-> atomically.
+> unmatched citations, and local bge-small embeddings. Running
+> `jurisd fetch-module legislation-cth` downloads the manifest and parquet files
+> from Hugging Face, verifies every file against the manifest sha256 values, and
+> installs the module atomically.
 
 Modules are queried in place: DuckDB scans the parquet on disk and never
 materialises a whole table into memory, so a host can install many modules
@@ -178,9 +178,9 @@ Modules are **operator-installed via the CLI** (kept off the tool surface so an
 LLM never triggers a large download mid-conversation):
 
 ```bash
-jurisd fetch-module <name> [--version X.Y.Z]   # download + sha256-verify + atomic install
-jurisd verify-module <name>                     # re-verify installed files against the manifest
-jurisd list-modules                             # list installed modules (incl. refused)
+jurisd fetch-module <name> [--modules-dir DIR]   # download + sha256-verify + atomic install
+jurisd verify-module <name> [--modules-dir DIR]  # re-verify installed files against the manifest
+jurisd list-modules [--modules-dir DIR]          # list installed modules (incl. refused)
 ```
 
 The default install root is `~/.jurisd/modules/` (override with
@@ -189,6 +189,11 @@ and checks the schema version **before** downloading any parquet, sha256-verifie
 every file against the manifest, installs atomically (temp-then-rename, so a
 half-written module never appears), and prints the licence attribution lines at
 install time.
+
+Advanced operators can pass `--manifest-url URL` to install from an explicitly
+trusted manifest. The sha256 checks prove downloaded files match that manifest;
+they do not prove the manifest's provenance or protect against a malicious or
+compromised manifest source.
 
 ### Baseline vs domain-specialised variants
 
@@ -227,10 +232,9 @@ into a tool result.
 ## Quality
 
 jurisd's local data layer is built and scored honestly against a gold set. The
-`jurisd-data` gold-set evaluation (to be published alongside the first module
-release; the `jurisd-data` repo is still being built) measures the local enricher
-(segments, defined terms, citation crossrefs) against 90 Open Australian Legal
-Corpus / Kanon ILDGS documents, under two parallel metrics:
+`jurisd-data` gold-set evaluation measures the local enricher (segments, defined
+terms, citation crossrefs) against 90 Open Australian Legal Corpus / Kanon ILDGS
+documents, under two parallel metrics:
 
 - **strict** — the conservative audit metric: every typed prediction unmatched
   within its type is a false positive.
@@ -244,8 +248,9 @@ citation precision, citation recall, defined-term F1). Headline segment F1 is
 0.44 strict / 0.64 aligned against a 0.85 gate. The report localises every gap
 to a specific rule (the residual segment gap is genuine over-segmentation, chiefly
 an endnotes-boundary flood; citation precision is internal-ref over-firing on
-structural lines). It is published in full, both metrics, as the honest current
-state, not a marketing number.
+structural lines). The published module exposes the resulting data artefacts;
+evaluation reports remain part of the module publishing workflow until a public
+report location is available.
 
 ## Licensing
 
@@ -265,8 +270,7 @@ state, not a marketing number.
     case-law sources are redistributable under the CC-BY-4.0 aggregate, subject to
     per-source confirmation before each module publishes.
 
-The full per-source verdict table lives in `jurisd-data/LICENSING.md`; each
-published module also carries its own `licence` block in `manifest.json`,
+Each published module carries its own `licence` block in `manifest.json`,
 surfaced at `fetch-module` install time.
 
 ## Documentation

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -234,20 +234,20 @@ mid-conversation. Modules are published as Hugging Face datasets under the
 > **Status: first module published.** `legislation-cth` is available from
 > `workingmem/legislation-cth` on Hugging Face. It provides Commonwealth primary
 > and secondary legislation, 32,143 documents, 857,262 chunks, citation edges,
-> unmatched citations, and local bge-small embeddings. `jurisd fetch-module
-legislation-cth` downloads the manifest and parquet files from Hugging Face,
-> verifies every file against the manifest sha256 values, and installs the module
-> atomically.
+> unmatched citations, and local bge-small embeddings. Running
+> `jurisd fetch-module legislation-cth` downloads the manifest and parquet files
+> from Hugging Face, verifies every file against the manifest sha256 values, and
+> installs the module atomically.
 
 ```bash
-jurisd fetch-module <name> [--manifest-url URL] [--modules-dir DIR]
+jurisd fetch-module <name> [--modules-dir DIR]
 jurisd verify-module <name> [--modules-dir DIR]
 jurisd list-modules [--modules-dir DIR]
 ```
 
 `fetch-module`:
 
-1. Resolves the module manifest from the default Hugging Face dataset URL, or from `--manifest-url`.
+1. Resolves the module manifest from the default Hugging Face dataset URL.
 2. Downloads `manifest.json` first and validates it against the vendored schema —
    checks the schema version is implemented and the release is not yanked
    **before** downloading any parquet (fail fast, save bandwidth).
@@ -266,6 +266,20 @@ installed and why a module is or is not loading.
 
 The default install root is `~/.jurisd/modules/` (override with
 `JURISD_MODULES_DIR` or `--modules-dir`).
+
+### Advanced manifest override
+
+Use `--manifest-url URL` only when the manifest source is explicitly trusted, for
+example a Hugging Face dataset and revision you operate or have independently
+reviewed:
+
+```bash
+jurisd fetch-module <name> --manifest-url URL [--modules-dir DIR]
+```
+
+`verify-module` checks installed files against the manifest. It does not prove
+the manifest's provenance or protect against a malicious or compromised manifest
+source.
 
 ## Offline / baseline guarantee
 

--- a/skills/jurisd-research/SKILL.md
+++ b/skills/jurisd-research/SKILL.md
@@ -123,14 +123,20 @@ Filter to one logical document with `document`. List/inspect with `op=list` / `o
   triggers a large download mid-conversation):
 
   ```bash
-  jurisd fetch-module <name> [--version X.Y.Z]   # download + sha256-verify + atomic install
-  jurisd verify-module <name>                     # re-verify installed files vs manifest
-  jurisd list-modules                             # list installed (incl. refused)
+  jurisd fetch-module <name> [--modules-dir DIR]   # download + sha256-verify + atomic install
+  jurisd verify-module <name> [--modules-dir DIR]  # re-verify installed files vs manifest
+  jurisd list-modules [--modules-dir DIR]          # list installed (incl. refused)
   ```
 
-  **No modules are published yet** — the `jurisd-data` release repo is still being built,
-  so `fetch-module` currently fails fast with a `404`. Lead with the live tools until the
-  first module lands; `list_data_modules` will report an empty store in the meantime.
+  `legislation-cth` is published as `workingmem/legislation-cth` on Hugging Face. It
+  provides Commonwealth primary and secondary legislation, citation edges, unmatched
+  citations, and local bge-small embeddings. `fetch-module` downloads the manifest and
+  parquet files, verifies each file against the manifest sha256 values, and installs the
+  module atomically.
+
+  Advanced operators can pass `--manifest-url URL` only for an explicitly trusted
+  manifest source. The sha256 checks prove files match that manifest; they do not prove
+  the manifest's provenance.
 
   Install root defaults to `~/.jurisd/modules/` (override `JURISD_MODULES_DIR`). Local
   tools need optional `@duckdb/node-api`; `semantic_search_local` also needs


### PR DESCRIPTION
## Requested

Make the module availability documentation match the current published module state instead of describing module publication as future work.

## Delivered

This PR removes stale wording that said no modules were published yet and documents `legislation-cth` as the first available module. It points users at the public Hugging Face dataset used by `jurisd fetch-module`, fixes the documented module CLI flags, adds trust-boundary guidance for `--manifest-url`, and updates the shipped `jurisd-research` skill so agents do not repeat stale install guidance.

The public docs no longer point readers at private `jurisd-data` release or licensing paths.

## Measurement

Validated the current module publication path end to end:

- Confirmed `workingmem/legislation-cth` exists on Hugging Face as a public dataset containing `manifest.json`, `documents.parquet`, `chunks.parquet`, `edges.parquet`, and `unmatched_citations.parquet`.
- Confirmed the public Hugging Face manifest matches the verified module manifest.
- Validated module artefacts against the manifest: sha256 values and row counts match for all four published parquet files.
- Ran `node dist/index.js fetch-module legislation-cth --modules-dir <tmp>` against the public Hugging Face endpoint. It downloaded the module, verified hashes, and installed atomically.
- Ran `node dist/index.js verify-module legislation-cth --modules-dir <tmp>`, which verified the installed module.
- Ran `node dist/index.js list-modules --modules-dir <tmp>`, which reported `legislation-cth` ready with 32,143 documents and 857,262 chunks.
- Ran stale-wording checks across `README.md`, `docs/INSTALL.md`, `skills/jurisd-research/SKILL.md`, and `docs/` for the removed no-module and private-path claims.
- Ran `npx prettier --check README.md docs/INSTALL.md skills/jurisd-research/SKILL.md`.
- Ran `npm pack --dry-run` to confirm the updated README is included in the package tarball.
- GitHub CI is green on the PR head.

## Review status

- Clean code review: complete
- Deep security review: complete
