### PR TITLE
release: jurisd v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 No changes yet.
 
+## [0.3.0] - 2026-06-21
+
+### Added
+
+- **Exa search fallback for AustLII** (#141): AustLII now serves a JS managed
+  Cloudflare challenge across its whole origin that TLS impersonation (`impit`)
+  cannot clear. `search_cases` / `search_legislation` now run the free providers
+  resiliently (`Promise.allSettled`) so a Cloudflare block no longer fails the
+  whole search; when the free providers return nothing, jurisd falls back to Exa
+  neural search (`EXA_API_KEY`), which returns canonical `austlii.edu.au` case
+  and legislation URLs.
+- **Degraded-coverage reporting in the CLI** (#142): search results now report
+  when coverage is degraded (a source was blocked or unreachable) instead of
+  silently returning a partial set.
+- **Inline TUI scaffold** (`src/tui.ts`): a first interactive terminal UI scaffold.
+- **Multi-harness setup guide** (`docs/HARNESS-SETUP.md`): copy-paste MCP configs
+  for Claude Code, Claude Desktop, Cursor, Windsurf, VS Code, Cline, Continue,
+  OpenAI Codex CLI, Zed, Gemini CLI, and JetBrains.
+
+### Changed
+
+- **Hardened AustLII Cloudflare fallbacks** (#140): degrade gracefully across the
+  live layer when the AustLII origin returns a managed challenge, rather than
+  fighting the fingerprint arms race.
+- **Fail closed on malformed jade.io search responses**: reject and report rather
+  than surfacing partial or garbled citator/search data.
+- **Hardened rendered formatter output** and **package install/startup** for
+  `npx`-from-GitHub and global installs (reliable `jurisd` bin linking and build
+  for GitHub installs).
+
+### Packaging
+
+- **npm-publishable**: the published tarball now ships `NOTICE` and
+  `LICENSE-THIRD-PARTY.md` (Apache-2.0 §4(d) NOTICE-distribution requirement) and
+  is verified to contain no test artifacts; the vendored data-module manifest
+  schema (`dist/data/manifest.schema.json`) ships for offline manifest validation.
+
+### Documentation
+
+- Documented the first published data module, `legislation-cth` on Hugging Face
+  (`workingmem/legislation-cth`): Commonwealth primary and secondary legislation,
+  32,143 documents, 857,262 chunks, citation edges, and local bge-small
+  embeddings, installed via `jurisd fetch-module legislation-cth` (#133, #139).
+- Clarified the GitHub install commands (tarball archive vs bare git install and
+  the `install-links` caveat).
+
 ## [0.2.0] - 2026-06-16
 
 ### Added
@@ -151,6 +197,7 @@ legal research across AustLII and jade.io.
 - Source-store citeKey hardening against path traversal (#108)
 - Dependency updates resolving known HIGH severity advisories; npm audit in CI
 
-[Unreleased]: https://github.com/russellbrenner/jurisd/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/russellbrenner/jurisd/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/russellbrenner/jurisd/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/russellbrenner/jurisd/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/russellbrenner/jurisd/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Or add it to your client config directly:
 }
 ```
 
+Using a different agent? [docs/HARNESS-SETUP.md](docs/HARNESS-SETUP.md) has
+copy-paste configs for Cursor, Windsurf, VS Code, Cline, Continue, Codex CLI,
+Zed, Gemini CLI, and more.
+
 All environment variables are **optional** — with none set, the live AustLII
 layer and the local-module recall layer both work. See
 [docs/INSTALL.md](docs/INSTALL.md) for the local-clone path, every config option,
@@ -116,12 +120,12 @@ and AGLC4 prompts once the `jurisd` MCP server is registered.
 > directly. Configure a **fallback source**; results are still AustLII primary
 > sources (`austlii.edu.au` URLs) recovered through another channel.
 >
-> | Fallback   | Env var               | Cost              | You gain                                                                                        | You lose                                                                 |
-> | ---------- | --------------------- | ----------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-> | **Exa**    | `EXA_API_KEY`         | Paid (free tier)  | Neural search returns the canonical AustLII case/legislation URL (usually rank #1), even for obscure cases. | Discovery only (URL + citation); full text is fetched separately.        |
-> | **jade.io**| `JADE_SESSION_COOKIE` | Free (account)    | Full-text search **and** document retrieval via jade.io, plus the citator.                      | Needs a jade.io account; the session cookie expires and must be re-extracted. |
-> | **both**   | both of the above     | —                 | Best coverage — jade runs first (free), Exa fills the gaps it misses.                            | —                                                                        |
-> | **none**   | —                     | —                 | —                                                                                               | Search returns a degraded result whose warning names the env vars; document fetch still falls back to the local OALC corpus when available. |
+> | Fallback    | Env var               | Cost             | You gain                                                                                                    | You lose                                                                                                                                    |
+> | ----------- | --------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+> | **Exa**     | `EXA_API_KEY`         | Paid (free tier) | Neural search returns the canonical AustLII case/legislation URL (usually rank #1), even for obscure cases. | Discovery only (URL + citation); full text is fetched separately.                                                                           |
+> | **jade.io** | `JADE_SESSION_COOKIE` | Free (account)   | Full-text search **and** document retrieval via jade.io, plus the citator.                                  | Needs a jade.io account; the session cookie expires and must be re-extracted.                                                               |
+> | **both**    | both of the above     | —                | Best coverage — jade runs first (free), Exa fills the gaps it misses.                                       | —                                                                                                                                           |
+> | **none**    | —                     | —                | —                                                                                                           | Search returns a degraded result whose warning names the env vars; document fetch still falls back to the local OALC corpus when available. |
 >
 > Resolution order: free providers (jade live + AustLII, in case Cloudflare ever
 > relaxes) → Exa → degraded result. The document source remains AustLII throughout.
@@ -302,6 +306,7 @@ surfaced at `fetch-module` install time.
 | Document                                                 | Description                                                                |
 | -------------------------------------------------------- | -------------------------------------------------------------------------- |
 | [INSTALL.md](docs/INSTALL.md)                            | Day-0 install paths, Claude Code config, env vars, module flow             |
+| [HARNESS-SETUP.md](docs/HARNESS-SETUP.md)                | Copy-paste MCP config for every popular coding agent (CC, Cursor, Zed, …)  |
 | [CLI.md](docs/CLI.md)                                    | CLI command shape, compatibility aliases, output rules, exit codes         |
 | [MCP-COMPATIBILITY.md](docs/MCP-COMPATIBILITY.md)        | Compatibility reference for the current MCP tool surface                   |
 | [SECURITY-AUTHORITY.md](docs/SECURITY-AUTHORITY.md)      | Command authority, side-effect classes, terminal safety, credential rules  |

--- a/docs/HARNESS-SETUP.md
+++ b/docs/HARNESS-SETUP.md
@@ -1,0 +1,240 @@
+# Coding-harness setup
+
+jurisd is a stdio Model Context Protocol (MCP) server. Every MCP-capable
+coding agent launches it the same way — over standard input/output. Only the
+**config file location** and **wrapper format** differ per harness. This page
+gives a copy-paste config for each popular harness.
+
+## The one command that never changes
+
+Whatever the harness, the server is launched by one of these:
+
+| Form                                  | When to use                                    |
+| ------------------------------------- | ---------------------------------------------- |
+| `npx -y jurisd`                       | Once jurisd is published to the npm registry.  |
+| `npx -y github:russellbrenner/jurisd` | Before the npm publish (installs from GitHub). |
+| `node /path/to/jurisd/dist/index.js`  | A local clone you build yourself.              |
+
+Every snippet below uses `npx -y jurisd`. **Pre-publish, substitute
+`github:russellbrenner/jurisd` for `jurisd`** in the `args` — nothing else
+changes. For a local clone, set `command` to `node` and `args` to the absolute
+path of `dist/index.js`.
+
+All env vars are optional (jurisd answers offline with no key). To pass one
+— e.g. your jade.io subscription cookie — add an `env` block to the server
+entry. See [INSTALL.md](INSTALL.md) for the full env-var reference.
+
+---
+
+## Claude Code
+
+CLI (fastest):
+
+```bash
+claude mcp add jurisd -- npx -y jurisd
+```
+
+`--scope` controls visibility: `local` (default, private to you in this
+project), `project` (written to a committed `.mcp.json`, shared with the
+team), `user` (available in all your projects):
+
+```bash
+claude mcp add --scope project jurisd -- npx -y jurisd
+```
+
+Or edit a project `.mcp.json` directly:
+
+```json
+{
+  "mcpServers": {
+    "jurisd": {
+      "command": "npx",
+      "args": ["-y", "jurisd"]
+    }
+  }
+}
+```
+
+## Claude Desktop
+
+Edit `claude_desktop_config.json`:
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "jurisd": {
+      "command": "npx",
+      "args": ["-y", "jurisd"],
+      "env": { "JADE_SESSION_COOKIE": "" }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing. (Remove the `env` block if you are not
+setting a jade.io cookie.)
+
+## Cursor
+
+Project: `.cursor/mcp.json`. Global: `~/.cursor/mcp.json`.
+
+```json
+{
+  "mcpServers": {
+    "jurisd": {
+      "command": "npx",
+      "args": ["-y", "jurisd"]
+    }
+  }
+}
+```
+
+## Windsurf
+
+Edit `~/.codeium/windsurf/mcp_config.json` (or use Cascade →
+Plugins/MCP → "Manage" → "View raw config"):
+
+```json
+{
+  "mcpServers": {
+    "jurisd": {
+      "command": "npx",
+      "args": ["-y", "jurisd"]
+    }
+  }
+}
+```
+
+## VS Code (GitHub Copilot agent mode)
+
+VS Code uses a **`servers`** key (not `mcpServers`) and requires an explicit
+`type`. Project: `.vscode/mcp.json`. You can also run **MCP: Add Server** from
+the Command Palette.
+
+```json
+{
+  "servers": {
+    "jurisd": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "jurisd"]
+    }
+  }
+}
+```
+
+## Cline (VS Code extension)
+
+Open the Cline panel → **MCP Servers** → **Configure MCP Servers**, which opens
+`cline_mcp_settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "jurisd": {
+      "command": "npx",
+      "args": ["-y", "jurisd"]
+    }
+  }
+}
+```
+
+## Continue
+
+Edit `~/.continue/config.yaml` (global) or a project `.continue/config.yaml`.
+Continue's YAML uses an `mcpServers` **list**:
+
+```yaml
+mcpServers:
+  - name: jurisd
+    type: stdio
+    command: npx
+    args:
+      - "-y"
+      - jurisd
+```
+
+## OpenAI Codex CLI
+
+Edit `~/.codex/config.toml` (or a project `.codex/config.toml`). MCP servers
+are TOML tables keyed by name:
+
+```toml
+[mcp_servers.jurisd]
+command = "npx"
+args = ["-y", "jurisd"]
+```
+
+Add an env table if needed: `env = { JADE_SESSION_COOKIE = "" }`.
+
+## Zed
+
+Edit `settings.json` (Command Palette → **zed: open settings**). Zed uses a
+`context_servers` object keyed by name:
+
+```json
+{
+  "context_servers": {
+    "jurisd": {
+      "command": "npx",
+      "args": ["-y", "jurisd"],
+      "env": {}
+    }
+  }
+}
+```
+
+You can also add it via the Agent Panel settings → **Add Custom Server**.
+
+## Gemini CLI
+
+Edit `~/.gemini/settings.json` (global) or a project `.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "jurisd": {
+      "command": "npx",
+      "args": ["-y", "jurisd"]
+    }
+  }
+}
+```
+
+## JetBrains AI Assistant / Junie
+
+JetBrains accepts the standard `mcpServers` JSON. **Settings → Tools → AI
+Assistant → Model Context Protocol (MCP) → Add**, then either fill in
+`command` = `npx`, `args` = `-y jurisd`, or paste the same JSON block used for
+Claude Desktop above.
+
+## Any other MCP client
+
+The lowest common denominator is a stdio server with:
+
+- **command**: `npx`
+- **args**: `["-y", "jurisd"]`
+- **env**: optional, all keys optional (see [INSTALL.md](INSTALL.md))
+
+---
+
+## Verify it works
+
+After wiring it up, confirm the 15-tool surface is live. From a clone you can
+run the stdio handshake check directly:
+
+```bash
+node scripts/docker-handshake.mjs    # or: npm run build && npm start
+```
+
+In your agent, ask it to list its tools or call `list_data_modules` — jurisd
+answers from the offline module layer even with no key and no network. If the
+agent reports zero jurisd tools, check that `npx` is on the PATH the harness
+launches with, and that the harness was restarted after editing its config.
+
+See also: [INSTALL.md](INSTALL.md) (install paths + env vars),
+[MCP-COMPATIBILITY.md](MCP-COMPATIBILITY.md) (the stable tool surface),
+[DOCKER.md](DOCKER.md) (container wiring).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jurisd",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jurisd",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jurisd",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Model Context Protocol server for Australian legislation and case law search.",
   "main": "dist/index.js",
   "bin": {
@@ -9,7 +9,9 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "NOTICE",
+    "LICENSE-THIRD-PARTY.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node -e \"const fs=require('fs');fs.mkdirSync('dist/data',{recursive:true});fs.copyFileSync('src/data/manifest.schema.json','dist/data/manifest.schema.json');fs.chmodSync('dist/index.js',0o755)\"",


### PR DESCRIPTION
## Summary

Prepares the **v0.3.0** release and brings jurisd to an npm-publishable state.

- **Version**: bump `0.2.0` → `0.3.0` (package.json + lockfile).
- **npm-publishable**: the published tarball now ships `NOTICE` and `LICENSE-THIRD-PARTY.md` (Apache-2.0 §4(d) NOTICE-distribution requirement). Verified tarball is free of test artifacts (158 files, ~191KB) and includes the vendored data-module manifest schema (`dist/data/manifest.schema.json`).
- **CHANGELOG** `[0.3.0]` populated from the 16 commits since v0.2.0: Exa AustLII fallback (#141), degraded-coverage reporting, inline TUI scaffold, Cloudflare/jade hardening (#140), and `legislation-cth` module docs (#139).
- **New doc** `docs/HARNESS-SETUP.md`: copy-paste MCP config for every popular coding agent — Claude Code, Claude Desktop, Cursor, Windsurf, VS Code, Cline, Continue, OpenAI Codex CLI, Zed, Gemini CLI, JetBrains. Each non-trivial format (VS Code `servers`, Zed `context_servers`, Codex TOML, Continue YAML) verified against official docs. Linked from README.

No source changes — docs + packaging metadata only. `npm run check:dist` passes (clean build matches committed dist).

## Release flow after merge

Tag `v0.3.0` on the merge commit → `release.yml` builds, tests, and creates the GitHub Release from the CHANGELOG `[0.3.0]` section. **The actual `npm publish` to the registry is intentionally manual** (needs registry auth; first-time publish of the `jurisd` name).

## Test plan

- [x] `npm run check:dist` — clean build reproduces committed dist
- [x] `npm pack --dry-run` — 158 files, no test/secret artifacts, ships NOTICE + LICENSE-THIRD-PARTY + manifest schema
- [x] CHANGELOG release-notes `awk` extraction verified non-empty for 0.3.0
- [ ] CI (main.yml): lint + typecheck + Node test matrix green