### PR TITLE
feat: Publish release tags to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -19,8 +20,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22.x"
-          cache: "npm"
+          node-version: "24.x"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci
@@ -34,6 +36,22 @@ jobs:
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate package version
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          node <<'NODE'
+          const pkg = require("./package.json");
+          const expected = process.env.VERSION;
+          if (pkg.version !== expected) {
+            console.error(`package.json version ${pkg.version} does not match tag v${expected}`);
+            process.exit(1);
+          }
+          NODE
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
 
       - name: Extract release notes from CHANGELOG
         id: changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No changes yet.
+### Changed
+
+- Added npm publication to the tag release workflow and made npm registry
+  installs the primary documented install path, with GitHub installs retained for
+  unreleased branch builds.
 
 ## [0.3.0] - 2026-06-21
 

--- a/README.md
+++ b/README.md
@@ -40,28 +40,26 @@ live results — when you supply your own session cookie.
 ### Run with npx (no clone)
 
 ```bash
-npx -y github:russellbrenner/jurisd
+npx -y jurisd
 ```
 
-`npx` installs the package from its built distribution and launches the server
-over stdio in one step.
+`npx` installs the published package and launches the server over stdio in one
+step.
 
-### Install the CLI persistently from GitHub
+### Install the CLI persistently
 
 ```bash
-npm install -g https://github.com/russellbrenner/jurisd/archive/refs/heads/main.tar.gz
+npm install -g jurisd
 jurisd --help
 ```
 
-Use the GitHub tarball form for persistent installs before the npm registry
-package is published. Bare git installs such as `npm install -g
-github:russellbrenner/jurisd` depend on npm's `install-links` setting and can
-leave a broken global bin on hosts where `install-links=false`.
+Need an unreleased branch build? Use `npx -y github:russellbrenner/jurisd#main`
+or the GitHub tarball form documented in [docs/INSTALL.md](docs/INSTALL.md).
 
 ### Register with Claude Code
 
 ```bash
-claude mcp add jurisd -- npx -y github:russellbrenner/jurisd
+claude mcp add jurisd -- npx -y jurisd
 ```
 
 Or add it to your client config directly:
@@ -71,7 +69,7 @@ Or add it to your client config directly:
   "mcpServers": {
     "jurisd": {
       "command": "npx",
-      "args": ["-y", "github:russellbrenner/jurisd"]
+      "args": ["-y", "jurisd"]
     }
   }
 }

--- a/docs/HARNESS-SETUP.md
+++ b/docs/HARNESS-SETUP.md
@@ -11,14 +11,14 @@ Whatever the harness, the server is launched by one of these:
 
 | Form                                  | When to use                                    |
 | ------------------------------------- | ---------------------------------------------- |
-| `npx -y jurisd`                       | Once jurisd is published to the npm registry.  |
-| `npx -y github:russellbrenner/jurisd` | Before the npm publish (installs from GitHub). |
+| `npx -y jurisd`                       | Default npm registry install.                  |
+| `npx -y github:russellbrenner/jurisd` | Unreleased branch or main build validation.    |
 | `node /path/to/jurisd/dist/index.js`  | A local clone you build yourself.              |
 
-Every snippet below uses `npx -y jurisd`. **Pre-publish, substitute
-`github:russellbrenner/jurisd` for `jurisd`** in the `args` — nothing else
-changes. For a local clone, set `command` to `node` and `args` to the absolute
-path of `dist/index.js`.
+Every snippet below uses `npx -y jurisd`. For an unreleased branch build,
+substitute `github:russellbrenner/jurisd#main` (or another ref) for `jurisd` in
+the `args`. For a local clone, set `command` to `node` and `args` to the
+absolute path of `dist/index.js`.
 
 All env vars are optional (jurisd answers offline with no key). To pass one
 — e.g. your jade.io subscription cookie — add an `env` block to the server

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -10,18 +10,17 @@ live AustLII layer needs network but no key; its Cloudflare-aware transport is a
 normal production dependency so hosted installs do not silently lose direct
 document fetch capability.
 
-## Day-0 install paths
+## Install paths
 
-### A. npx from GitHub (no clone)
+### A. npx from npm (no clone)
 
 ```bash
-npx -y github:russellbrenner/jurisd
+npx -y jurisd
 ```
 
-`npx` installs the package from the built distribution and launches the server
-over stdio. The first invocation does the clone and install; subsequent launches
-reuse the cached install. Pin a ref by appending `#<ref>` — e.g.
-`github:russellbrenner/jurisd#main`.
+`npx` installs the published package and launches the server over stdio. The
+first invocation downloads and installs the package; subsequent launches reuse
+the cached install.
 
 The native local-data package (`@duckdb/node-api`) and local embedding stack
 (`@huggingface/transformers` and its native dependencies) are optional because
@@ -37,34 +36,24 @@ Cloudflare-aware AustLII transport.
 
 ### B. npm global install
 
-Once the package is published to the npm registry, install the CLI globally with:
-
 ```bash
 npm install -g jurisd
 jurisd --help
 ```
 
-Before the registry publish, use the GitHub tarball archive for a persistent
-install:
+### C. GitHub branch or tarball fallback
+
+Use GitHub installs only when validating an unreleased branch or when the npm
+registry package is temporarily unavailable.
 
 ```bash
+npx -y github:russellbrenner/jurisd#main
 npm install -g https://github.com/russellbrenner/jurisd/archive/refs/heads/main.tar.gz
 jurisd --help
 ```
 
-The tarball archive materialises the package in the global prefix and creates a
-stable `jurisd` bin link. A bare git install such as `npm install -g
-github:russellbrenner/jurisd` depends on npm's `install-links` setting and can
-leave the global `jurisd` bin pointing at a temporary git clone that has already
-been removed on hosts where `install-links=false` is configured.
-
-If you intentionally want the bare git install form, force npm's linked install
-mode:
-
-```bash
-npm install -g --install-links=true github:russellbrenner/jurisd
-jurisd --help
-```
+Prefer the tarball form for persistent GitHub installs. Bare git global installs
+depend on npm's link mode and are not the supported persistent fallback.
 
 ## Optional native dependencies
 
@@ -86,7 +75,7 @@ npm install -g @duckdb/node-api@1.5.3-r.3
 npm install -g @huggingface/transformers@3.7.6
 ```
 
-### C. Local clone + npm
+### D. Local clone + npm
 
 ```bash
 git clone https://github.com/russellbrenner/jurisd.git
@@ -103,7 +92,7 @@ For local development use `npm run dev` (hot reload) instead of `build` + `start
 The fastest path:
 
 ```bash
-claude mcp add jurisd -- npx -y github:russellbrenner/jurisd
+claude mcp add jurisd -- npx -y jurisd
 ```
 
 Or, for a local clone:
@@ -124,7 +113,7 @@ If your client edits a JSON config directly (Claude Desktop's
   "mcpServers": {
     "jurisd": {
       "command": "npx",
-      "args": ["-y", "github:russellbrenner/jurisd"]
+      "args": ["-y", "jurisd"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
   "bugs": {
     "url": "https://github.com/russellbrenner/jurisd/issues"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "author": "Russell Brenner",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Requested

Publish jurisd through npm and make the install instructions default to the npm package instead of GitHub install forms.

## Delivered

This PR updates the tag release workflow to publish the package to the public npm registry using GitHub-hosted release infrastructure, OIDC permission, npm provenance, and an explicit package-version-to-tag check before publishing.

The package metadata now declares the public npm registry target. The README, install guide, and harness setup guide now use `npx -y jurisd` and `npm install -g jurisd` as the primary paths, with GitHub installs retained only for unreleased branch validation or temporary registry fallback.

## Measurement

Validated the release and install path with the repository checks and a package smoke test:

- `npm run build`
- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run check:dist`
- `npm run check:generated`
- `npm pack` into a temporary directory, followed by `npm exec --yes --package <tarball> -- jurisd --help`

The npm registry currently returns no public `jurisd` package. A tagged release will publish successfully only after npm package ownership/trusted publishing is configured for `russellbrenner/jurisd` and `.github/workflows/release.yml`.

## Review status

- Clean code review: pending
- Deep security review: pending
